### PR TITLE
Add telemetry flush support and update dependencies

### DIFF
--- a/examples/base/src/base/main.py
+++ b/examples/base/src/base/main.py
@@ -12,7 +12,7 @@ async def main():
     load_dotenv()
 
     # Setup OpenTelemetry before anything else happens
-    init_otel(service_name="Junjo Base Example")
+    exporter = init_otel(service_name="Junjo Base Example")
 
     # Subscribe to state changes
     def on_state_change(new_state: SampleWorkflowState):
@@ -27,6 +27,11 @@ async def main():
     await unsubscribe()
 
     print("Done executing the base example workflow.")
+
+    # Flush telemetry before exit
+    if exporter is not None:
+        print("Flushing telemetry...")
+        exporter.flush()
     return
 
 if __name__ == "__main__":

--- a/examples/base/src/base/otel_config.py
+++ b/examples/base/src/base/otel_config.py
@@ -8,7 +8,7 @@ from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace import TracerProvider
 
 
-def init_otel(service_name: str):
+def init_otel(service_name: str) -> JunjoServerOtelExporter | None:
     """Configure OpenTelemetry for this application."""
 
     # Load the JUNJO_SERVER_API_KEY from the environment variable
@@ -16,7 +16,7 @@ def init_otel(service_name: str):
     if JUNJO_SERVER_API_KEY is None:
         print("JUNJO_SERVER_API_KEY environment variable is not set. "
                          "Generate a new API key in the Junjo Server UI.")
-        return
+        return None
 
     # Configure OpenTelemetry for this application
     # Create the OpenTelemetry Resource to identify this service
@@ -51,3 +51,5 @@ def init_otel(service_name: str):
     # Instrument OpenInference Libraries
     # Google genai
     GoogleGenAIInstrumentor().instrument(tracer_provider=tracer_provider)
+
+    return junjo_server_exporter

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "junjo"
-version = "0.60.2"
+version = "0.61.0"
 description = "A graph workflow execution library for building agentic AI workflows."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,11 +21,11 @@ classifiers = [
 ]
 
 dependencies = [
-    "grpcio>=1.70.0",
+    "grpcio>=1.75.1",
     "jsonpatch>=1.33",
     "nanoid>=2.0.0",
-    "opentelemetry-exporter-otlp-proto-grpc>=1.30.0",
-    "opentelemetry-sdk>=1.30.0",
+    "opentelemetry-exporter-otlp-proto-grpc>=1.37.0",
+    "opentelemetry-sdk>=1.37.0",
     "pydantic>=2.10.6",
 ]
 


### PR DESCRIPTION
## Summary

- Added `flush()` method to `JunjoServerOtelExporter` to allow block until all telemetry is exported
- Updated example application to call `flush()` to ensure delivery completes even when ingestion service starts late
- Bumped OpenTelemetry and gRPC dependencies to fix retry issues

## Changes

**Library (`JunjoServerOtelExporter`):**
- Added `flush(timeout_millis)` method with 120s default timeout to leverage gRPC retry logic
- Added explicit 120s timeout to `OTLPSpanExporter` initialization
- Returns boolean indicating flush success/failure

**Example application:**
- Updated `init_otel()` to return `JunjoServerOtelExporter` instance
- Added `exporter.flush()` call before application exit in `main.py`

**Dependencies:**
- `grpcio`: 1.70.0 → 1.75.1
- `opentelemetry-exporter-otlp-proto-grpc`: 1.30.0 → 1.37.0  
- `opentelemetry-sdk`: 1.30.0 → 1.37.0

## Why

Allows prevention of premature application exit before telemetry delivery completes, especially when testing scenarios where the ingestion service starts after the application has begun sending data.