### PR TITLE
chore: release 0.62.1 (AI Chat example update)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to Junjo will be documented in this file.
 
+## 0.62.1 - 2026-02-14
+
+This patch release focuses on updates to the AI Chat example.
+
+### Changed
+
+- Restored direct Gemini node usage across `examples/ai_chat` workflows instead of routing through provider abstractions.
+- Standardized Gemini model usage to `gemini-3-flash-preview` for text/schema generation and `gemini-2.5-flash-image` for image generation/editing flows.
+- Hardened Gemini schema request handling for empty/blocked responses and max-token edge cases.
+- Updated `examples/ai_chat/README.md` and backend `.env.example` so Gemini is the default path with Grok as an optional experimentation path.
+
 ## 0.62.0 - 2026-02-08
 
 This release is primarily a cleanup and polish pass across existing features.
@@ -39,4 +50,3 @@ and intentionally diverges from Junjo AI Studio version numbering.
 
 - This is mostly non-feature cleanup/polish, but consumers importing removed internal modules will need to migrate imports.
 - Example projects changed substantially; treat `examples/ai_chat` as an updated reference implementation rather than a drop-in patch.
-

--- a/examples/ai_chat/README.md
+++ b/examples/ai_chat/README.md
@@ -14,9 +14,15 @@ This is a more complete example of Junjo, showcasing:
 
 ## AI provider
 
-This example is currently wired up to use **xAI (Grok)** for text + image generation (via `GrokTool`).
+This example is currently wired up to use **Gemini** for all workflow AI calls via `GeminiTool`.
 
-If you'd rather use **Gemini**, you can swap the workflow nodes to use `GeminiTool` instead (both live in `backend/src/app/ai_services/`).
+Current node defaults:
+
+- Text generation / structured output: `gemini-3-flash-preview`
+- Image generation / image edit: `gemini-2.5-flash-image`
+
+For experimentation, you can switch specific nodes to `GrokTool` (or back) by editing the tool import and model in
+the node files under `backend/src/app/workflows/`.
 
 ## Run the example
 

--- a/examples/ai_chat/backend/.env.example
+++ b/examples/ai_chat/backend/.env.example
@@ -1,11 +1,13 @@
 # Create your Junjo AI Studio API Key inside Junjo Studio
 JUNJO_AI_STUDIO_API_KEY="[junjo_ai_studio_api_key_here]"
 
-# xAI is the currently setup provider of chat and image generation responses. 
-XAI_API_KEY="[xai_api_key_here]"
-
-# Junjo nodes can be configured to use GeminiTool instead of GrokTool
+# Current default implementation in workflow nodes uses GeminiTool with:
+# - text/schema model: gemini-3-flash-preview
+# - image model: gemini-2.5-flash-image
 GEMINI_API_KEY="[gemini_api_key_here]"
 
-# Required by xAI SDK to produce opentelemetry
+# Optional for experimentation if you switch any nodes to GrokTool
+XAI_API_KEY="[xai_api_key_here]"
+
+# Required by xAI SDK OTEL setup in app/otel_config.py (used when GrokTool is enabled)
 OTEL_EXPORTER_OTLP_PROTOCOL="grpc"

--- a/examples/ai_chat/backend/src/app/workflows/create_contact/avatar_subflow/nodes/avatar_inspiration/node.py
+++ b/examples/ai_chat/backend/src/app/workflows/create_contact/avatar_subflow/nodes/avatar_inspiration/node.py
@@ -1,7 +1,7 @@
 from junjo.node import Node
 from loguru import logger
 
-from app.ai_services.grok import GrokTool
+from app.ai_services.gemini.gemini_tool import GeminiTool
 from app.workflows.create_contact.avatar_subflow.nodes.avatar_inspiration.prompt import avatar_inspiration_prompt
 from app.workflows.create_contact.avatar_subflow.store import AvatarSubflowStore
 
@@ -46,11 +46,11 @@ class AvatarInspirationNode(Node[AvatarSubflowStore]):
         )
         logger.info(f"Creating response with prompt: {prompt}")
 
-        grok_tool = GrokTool(prompt=prompt, model="grok-4-1-fast-non-reasoning")
-        grok_result = await grok_tool.text_request()
-        logger.info(f"Grok result: {grok_result}")
+        gemini_tool = GeminiTool(prompt=prompt, model="gemini-3-flash-preview")
+        gemini_result = await gemini_tool.text_request()
+        logger.info(f"Gemini result: {gemini_result}")
 
         # Update the state with the avatar id
-        await store.set_inspiration_prompt(grok_result)
+        await store.set_inspiration_prompt(gemini_result)
 
         return

--- a/examples/ai_chat/backend/src/app/workflows/create_contact/avatar_subflow/nodes/create_avatar/node.py
+++ b/examples/ai_chat/backend/src/app/workflows/create_contact/avatar_subflow/nodes/create_avatar/node.py
@@ -2,7 +2,7 @@ from junjo.node import Node
 from loguru import logger
 from nanoid import generate
 
-from app.ai_services.grok import GrokTool
+from app.ai_services.gemini.gemini_tool import GeminiTool
 from app.util.save_image_file import save_image_file
 from app.workflows.create_contact.avatar_subflow.nodes.create_avatar.prompt import create_avatar_prompt
 from app.workflows.create_contact.avatar_subflow.store import AvatarSubflowStore
@@ -51,9 +51,9 @@ class CreateAvatarNode(Node[AvatarSubflowStore]):
         )
         logger.info(f"Creating image with prompt: {prompt}")
 
-        grok_tool = GrokTool(prompt=prompt, model="grok-imagine-image")
-        image_bytes = await grok_tool.image_request()
-        logger.info(f"Grok result image size: {len(image_bytes) / 1024} kb")
+        gemini_tool = GeminiTool(prompt=prompt, model="gemini-2.5-flash-image")
+        image_bytes = await gemini_tool.gemini_image_request()
+        logger.info(f"Gemini result image size: {len(image_bytes) / 1024} kb")
 
         # Create an id for the avatar
         avatar_id = generate()

--- a/examples/ai_chat/backend/src/app/workflows/create_contact/nodes/create_bio/node.py
+++ b/examples/ai_chat/backend/src/app/workflows/create_contact/nodes/create_bio/node.py
@@ -1,7 +1,7 @@
 from junjo.node import Node
 from loguru import logger
 
-from app.ai_services.grok import GrokTool
+from app.ai_services.gemini.gemini_tool import GeminiTool
 from app.workflows.create_contact.nodes.create_bio.prompt import create_bio_prompt
 from app.workflows.create_contact.store import CreateContactStore
 
@@ -38,11 +38,11 @@ class CreateBioNode(Node[CreateContactStore]):
         )
         logger.info(f"Creating response with prompt: {prompt}")
 
-        grok_tool = GrokTool(prompt=prompt, model="grok-4-1-fast-non-reasoning")
-        grok_result = await grok_tool.text_request()
-        logger.info(f"Grok result: {grok_result}")
+        gemini_tool = GeminiTool(prompt=prompt, model="gemini-3-flash-preview")
+        gemini_result = await gemini_tool.text_request()
+        logger.info(f"Gemini result: {gemini_result}")
 
         # Update the state with the bio
-        await store.set_bio(grok_result)
+        await store.set_bio(gemini_result)
 
         return

--- a/examples/ai_chat/backend/src/app/workflows/create_contact/nodes/create_bio/test/test_service.py
+++ b/examples/ai_chat/backend/src/app/workflows/create_contact/nodes/create_bio/test/test_service.py
@@ -1,4 +1,4 @@
-from app.ai_services.grok import GrokTool
+from app.ai_services.gemini.gemini_tool import GeminiTool
 from app.workflows.create_contact.nodes.create_bio.test.test_prompt import test_evaluate_bio_prompt
 from app.workflows.create_contact.nodes.create_bio.test.test_schema import TestCreateBioSchema
 
@@ -9,7 +9,7 @@ async def eval_create_bio_node(bio: str) -> TestCreateBioSchema:
     # Create the request to gemini for avatar inspiration
     prompt = test_evaluate_bio_prompt(bio)
 
-    grok_tool = GrokTool(prompt=prompt, model="grok-4-1-fast-non-reasoning")
-    grok_result = await grok_tool.schema_request(schema=TestCreateBioSchema)
+    gemini_tool = GeminiTool(prompt=prompt, model="gemini-3-flash-preview")
+    gemini_result = await gemini_tool.schema_request(schema=TestCreateBioSchema)
 
-    return grok_result
+    return gemini_result

--- a/examples/ai_chat/backend/src/app/workflows/create_contact/nodes/create_name/node.py
+++ b/examples/ai_chat/backend/src/app/workflows/create_contact/nodes/create_name/node.py
@@ -1,7 +1,7 @@
 from junjo.node import Node
 from loguru import logger
 
-from app.ai_services.grok import GrokTool
+from app.ai_services.gemini.gemini_tool import GeminiTool
 from app.workflows.create_contact.nodes.create_name.prompt import create_name_prompt
 from app.workflows.create_contact.nodes.create_name.schema import CreateNameSchema
 from app.workflows.create_contact.store import CreateContactStore
@@ -39,12 +39,12 @@ class CreateNameNode(Node[CreateContactStore]):
         )
         logger.info(f"Creating response with prompt: {prompt}")
 
-        grok_tool = GrokTool(prompt=prompt, model="grok-4-1-fast-non-reasoning")
-        grok_result = await grok_tool.schema_request(CreateNameSchema)
-        logger.info(f"Grok result: {grok_result}")
+        gemini_tool = GeminiTool(prompt=prompt, model="gemini-3-flash-preview")
+        gemini_result = await gemini_tool.schema_request(CreateNameSchema)
+        logger.info(f"Gemini result: {gemini_result}")
 
         # Update the state with the first name
-        await store.set_first_name(grok_result.first_name)
-        await store.set_last_name(grok_result.last_name)
+        await store.set_first_name(gemini_result.first_name)
+        await store.set_last_name(gemini_result.last_name)
 
         return

--- a/examples/ai_chat/backend/src/app/workflows/create_contact/nodes/select_location/services/get_nearest_city_state.py
+++ b/examples/ai_chat/backend/src/app/workflows/create_contact/nodes/select_location/services/get_nearest_city_state.py
@@ -1,6 +1,6 @@
 from loguru import logger
 
-from app.ai_services.grok import GrokTool
+from app.ai_services.gemini.gemini_tool import GeminiTool
 from app.workflows.create_contact.nodes.select_location.schemas import LocCityState
 from app.workflows.create_contact.nodes.select_location.services.get_nearest_city_state_prompt import (
     get_nearest_city_state_prompt,
@@ -16,8 +16,8 @@ async def get_nearest_city_state(lat: float, long: float) -> LocCityState:
     prompt = get_nearest_city_state_prompt(lat, long)
     logger.info(f"Creating response with prompt: {prompt}")
 
-    grok_tool = GrokTool(prompt=prompt, model="grok-4-1-fast-non-reasoning")
-    grok_result = await grok_tool.schema_request(schema=LocCityState)
-    logger.info(f"Grok result: {grok_result}")
+    gemini_tool = GeminiTool(prompt=prompt, model="gemini-3-flash-preview")
+    gemini_result = await gemini_tool.schema_request(schema=LocCityState)
+    logger.info(f"Gemini result: {gemini_result}")
 
-    return grok_result
+    return gemini_result

--- a/examples/ai_chat/backend/src/app/workflows/handle_message/create_response_with_image_subflow/nodes/image_inspiration/node.py
+++ b/examples/ai_chat/backend/src/app/workflows/handle_message/create_response_with_image_subflow/nodes/image_inspiration/node.py
@@ -1,7 +1,7 @@
 from junjo.node import Node
 from loguru import logger
 
-from app.ai_services.grok import GrokTool
+from app.ai_services.gemini.gemini_tool import GeminiTool
 from app.workflows.handle_message.create_response_with_image_subflow.nodes.image_inspiration.prompt import (
     image_inspiration_prompt,
 )
@@ -33,11 +33,11 @@ class ImageInspirationNode(Node[CreateResponseWithImageSubflowStore]):
         prompt = image_inspiration_prompt(parent_state.conversation_history, parent_state.contact)
         logger.info(f"Creating response with prompt: {prompt}")
 
-        grok_tool = GrokTool(prompt=prompt, model="grok-4-1-fast-non-reasoning")
-        grok_result = await grok_tool.text_request()
-        logger.info(f"Grok result: {grok_result}")
+        gemini_tool = GeminiTool(prompt=prompt, model="gemini-3-flash-preview")
+        gemini_result = await gemini_tool.text_request()
+        logger.info(f"Gemini result: {gemini_result}")
 
         # Update the state with the image id
-        await store.set_inspiration_prompt(grok_result)
+        await store.set_inspiration_prompt(gemini_result)
 
         return

--- a/examples/ai_chat/backend/src/app/workflows/handle_message/nodes/assess_message_directive/node.py
+++ b/examples/ai_chat/backend/src/app/workflows/handle_message/nodes/assess_message_directive/node.py
@@ -1,7 +1,7 @@
 from junjo.node import Node
 from loguru import logger
 
-from app.ai_services.grok import GrokTool
+from app.ai_services.gemini.gemini_tool import GeminiTool
 from app.workflows.handle_message.nodes.assess_message_directive.prompt_gemini import (
     assess_message_directive_prompt,
 )
@@ -19,18 +19,18 @@ class AssessMessageDirectiveNode(Node[MessageWorkflowStore]):
         prompt = assess_message_directive_prompt(state.conversation_history)
         logger.info(f"Prompt: {prompt}")
 
-        grok_tool = GrokTool(prompt=prompt, model="grok-4-1-fast-non-reasoning")
-        grok_result = await grok_tool.text_request()
-        logger.info(f"Grok result: {grok_result}")
+        gemini_tool = GeminiTool(prompt=prompt, model="gemini-3-flash-preview")
+        gemini_result = await gemini_tool.text_request()
+        logger.info(f"Gemini result: {gemini_result}")
 
         # Validate the result is a MessageDirective enum
-        if not grok_result:
-            raise ValueError("Grok result is empty.")
+        if not gemini_result:
+            raise ValueError("Gemini result is empty.")
 
         try:
-            message_directive = MessageDirective(grok_result)
+            message_directive = MessageDirective(gemini_result)
         except ValueError as e:
-            raise ValueError(f"Grok result '{grok_result}' is not a valid MessageDirective.") from e
+            raise ValueError(f"Gemini result '{gemini_result}' is not a valid MessageDirective.") from e
 
         # Update state
         await store.set_message_directive(message_directive)

--- a/examples/ai_chat/backend/src/app/workflows/handle_message/nodes/create_date_idea_response/node.py
+++ b/examples/ai_chat/backend/src/app/workflows/handle_message/nodes/create_date_idea_response/node.py
@@ -1,7 +1,7 @@
 from junjo.node import Node
 from loguru import logger
 
-from app.ai_services.grok import GrokTool
+from app.ai_services.gemini.gemini_tool import GeminiTool
 from app.db.models.message.repository import MessageRepository
 from app.db.models.message.schemas import MessageCreate
 from app.workflows.handle_message.nodes.create_date_idea_response.prompt_gemini import (
@@ -26,13 +26,13 @@ class CreateDateIdeaResponseNode(Node[MessageWorkflowStore]):
         )
         logger.info(f"Prompt: {prompt}")
 
-        grok_tool = GrokTool(prompt=prompt, model="grok-4-1-fast-non-reasoning")
-        grok_result = await grok_tool.text_request()
-        logger.info(f"Grok result: {grok_result}")
+        gemini_tool = GeminiTool(prompt=prompt, model="gemini-3-flash-preview")
+        gemini_result = await gemini_tool.text_request()
+        logger.info(f"Gemini result: {gemini_result}")
 
         # Create a message for the database
         message_create = MessageCreate(
-            chat_id=state.received_message.chat_id, contact_id=contact.id, message=grok_result
+            chat_id=state.received_message.chat_id, contact_id=contact.id, message=gemini_result
         )
 
         # Insert the message into the database

--- a/examples/ai_chat/backend/src/app/workflows/handle_message/nodes/create_general_response/node.py
+++ b/examples/ai_chat/backend/src/app/workflows/handle_message/nodes/create_general_response/node.py
@@ -1,7 +1,7 @@
 from junjo.node import Node
 from loguru import logger
 
-from app.ai_services.grok import GrokTool
+from app.ai_services.gemini.gemini_tool import GeminiTool
 from app.db.models.message.repository import MessageRepository
 from app.db.models.message.schemas import MessageCreate
 from app.workflows.handle_message.nodes.create_general_response.prompt_gemini import (
@@ -26,13 +26,13 @@ class CreateGeneralResponseNode(Node[MessageWorkflowStore]):
         )
         logger.info(f"Creating response with prompt: {prompt}")
 
-        grok_tool = GrokTool(prompt=prompt, model="grok-4-1-fast-non-reasoning")
-        grok_result = await grok_tool.text_request()
-        logger.info(f"Grok result: {grok_result}")
+        gemini_tool = GeminiTool(prompt=prompt, model="gemini-3-flash-preview")
+        gemini_result = await gemini_tool.text_request()
+        logger.info(f"Gemini result: {gemini_result}")
 
         # Create a message for the database
         message_create = MessageCreate(
-            chat_id=state.received_message.chat_id, contact_id=contact.id, message=grok_result
+            chat_id=state.received_message.chat_id, contact_id=contact.id, message=gemini_result
         )
 
         # Insert the message into the database

--- a/examples/ai_chat/backend/src/app/workflows/handle_message/nodes/create_work_response/node.py
+++ b/examples/ai_chat/backend/src/app/workflows/handle_message/nodes/create_work_response/node.py
@@ -1,7 +1,7 @@
 from junjo.node import Node
 from loguru import logger
 
-from app.ai_services.grok import GrokTool
+from app.ai_services.gemini.gemini_tool import GeminiTool
 from app.db.models.message.repository import MessageRepository
 from app.db.models.message.schemas import MessageCreate
 from app.workflows.handle_message.nodes.create_work_response.prompt_gemini import (
@@ -26,13 +26,13 @@ class CreateWorkResponseNode(Node[MessageWorkflowStore]):
         )
         logger.info(f"Prompt: {prompt}")
 
-        grok_tool = GrokTool(prompt=prompt, model="grok-4-1-fast-non-reasoning")
-        grok_result = await grok_tool.text_request()
-        logger.info(f"Grok result: {grok_result}")
+        gemini_tool = GeminiTool(prompt=prompt, model="gemini-3-flash-preview")
+        gemini_result = await gemini_tool.text_request()
+        logger.info(f"Gemini result: {gemini_result}")
 
         # Create a message for the database
         message_create = MessageCreate(
-            chat_id=state.received_message.chat_id, contact_id=contact.id, message=grok_result
+            chat_id=state.received_message.chat_id, contact_id=contact.id, message=gemini_result
         )
 
         # Insert the message into the database

--- a/examples/ai_chat/backend/src/app/workflows/sub_sub_flow/sub_flow_node_1/node.py
+++ b/examples/ai_chat/backend/src/app/workflows/sub_sub_flow/sub_flow_node_1/node.py
@@ -1,7 +1,7 @@
 from junjo.node import Node
 from loguru import logger
 
-from app.ai_services.grok import GrokTool
+from app.ai_services.gemini.gemini_tool import GeminiTool
 from app.workflows.sub_sub_flow.store import SubSubFlowStore
 
 
@@ -13,11 +13,11 @@ class SubSubFlowNode1(Node[SubSubFlowStore]):
         prompt = "Output a fact about apples."
         logger.info(f"Prompt: {prompt}")
 
-        grok_tool = GrokTool(prompt=prompt, model="grok-4-1-fast-non-reasoning")
-        grok_result = await grok_tool.text_request()
-        logger.info(f"Grok result: {grok_result}")
+        gemini_tool = GeminiTool(prompt=prompt, model="gemini-3-flash-preview")
+        gemini_result = await gemini_tool.text_request()
+        logger.info(f"Gemini result: {gemini_result}")
 
         # Update state
-        await store.append_fact(grok_result)
+        await store.append_fact(gemini_result)
 
         return

--- a/examples/ai_chat/backend/src/app/workflows/sub_sub_flow/sub_flow_node_2/node.py
+++ b/examples/ai_chat/backend/src/app/workflows/sub_sub_flow/sub_flow_node_2/node.py
@@ -1,7 +1,7 @@
 from junjo.node import Node
 from loguru import logger
 
-from app.ai_services.grok import GrokTool
+from app.ai_services.gemini.gemini_tool import GeminiTool
 from app.workflows.sub_sub_flow.store import SubSubFlowStore
 
 
@@ -13,11 +13,11 @@ class SubSubFlowNode2(Node[SubSubFlowStore]):
         prompt = "Output a fact about whales."
         logger.info(f"Prompt: {prompt}")
 
-        grok_tool = GrokTool(prompt=prompt, model="grok-4-1-fast-non-reasoning")
-        grok_result = await grok_tool.text_request()
-        logger.info(f"Grok result: {grok_result}")
+        gemini_tool = GeminiTool(prompt=prompt, model="gemini-3-flash-preview")
+        gemini_result = await gemini_tool.text_request()
+        logger.info(f"Gemini result: {gemini_result}")
 
         # Update state
-        await store.append_fact(grok_result)
+        await store.append_fact(gemini_result)
 
         return

--- a/examples/ai_chat/backend/src/app/workflows/sub_sub_flow/sub_flow_node_3/node.py
+++ b/examples/ai_chat/backend/src/app/workflows/sub_sub_flow/sub_flow_node_3/node.py
@@ -1,7 +1,7 @@
 from junjo.node import Node
 from loguru import logger
 
-from app.ai_services.grok import GrokTool
+from app.ai_services.gemini.gemini_tool import GeminiTool
 from app.workflows.sub_sub_flow.store import SubSubFlowStore
 
 
@@ -13,11 +13,11 @@ class SubSubFlowNode3(Node[SubSubFlowStore]):
         prompt = "Output a fact about cellular division."
         logger.info(f"Prompt: {prompt}")
 
-        grok_tool = GrokTool(prompt=prompt, model="grok-4-1-fast-non-reasoning")
-        grok_result = await grok_tool.text_request()
-        logger.info(f"Grok result: {grok_result}")
+        gemini_tool = GeminiTool(prompt=prompt, model="gemini-3-flash-preview")
+        gemini_result = await gemini_tool.text_request()
+        logger.info(f"Gemini result: {gemini_result}")
 
         # Update state
-        await store.append_fact(grok_result)
+        await store.append_fact(gemini_result)
 
         return

--- a/examples/ai_chat/backend/src/app/workflows/test_sub_flow/sub_flow_node_1/node.py
+++ b/examples/ai_chat/backend/src/app/workflows/test_sub_flow/sub_flow_node_1/node.py
@@ -1,7 +1,7 @@
 from junjo.node import Node
 from loguru import logger
 
-from app.ai_services.grok import GrokTool
+from app.ai_services.gemini.gemini_tool import GeminiTool
 from app.workflows.test_sub_flow.store import TestSubFlowStore
 
 
@@ -13,11 +13,11 @@ class SubFlowNode1(Node[TestSubFlowStore]):
         prompt = 'Output a joke about a piece of butter prepended by "SubFlowNode1:"'
         logger.info(f"Prompt: {prompt}")
 
-        grok_tool = GrokTool(prompt=prompt, model="grok-4-1-fast-non-reasoning")
-        grok_result = await grok_tool.text_request()
-        logger.info(f"Grok result: {grok_result}")
+        gemini_tool = GeminiTool(prompt=prompt, model="gemini-3-flash-preview")
+        gemini_result = await gemini_tool.text_request()
+        logger.info(f"Gemini result: {gemini_result}")
 
         # Update state
-        await store.append_joke(grok_result)
+        await store.append_joke(gemini_result)
 
         return

--- a/examples/ai_chat/backend/src/app/workflows/test_sub_flow/sub_flow_node_2/node.py
+++ b/examples/ai_chat/backend/src/app/workflows/test_sub_flow/sub_flow_node_2/node.py
@@ -1,7 +1,7 @@
 from junjo.node import Node
 from loguru import logger
 
-from app.ai_services.grok import GrokTool
+from app.ai_services.gemini.gemini_tool import GeminiTool
 from app.workflows.test_sub_flow.store import TestSubFlowStore
 
 
@@ -13,11 +13,11 @@ class SubFlowNode2(Node[TestSubFlowStore]):
         prompt = 'Output a joke about a very large lasagna prepended by "SubFlowNode2:"'
         logger.info(f"Prompt: {prompt}")
 
-        grok_tool = GrokTool(prompt=prompt, model="grok-4-1-fast-non-reasoning")
-        grok_result = await grok_tool.text_request()
-        logger.info(f"Grok result: {grok_result}")
+        gemini_tool = GeminiTool(prompt=prompt, model="gemini-3-flash-preview")
+        gemini_result = await gemini_tool.text_request()
+        logger.info(f"Gemini result: {gemini_result}")
 
         # Update state
-        await store.append_joke(grok_result)
+        await store.append_joke(gemini_result)
 
         return

--- a/examples/ai_chat/backend/src/app/workflows/test_sub_flow/sub_flow_node_3/node.py
+++ b/examples/ai_chat/backend/src/app/workflows/test_sub_flow/sub_flow_node_3/node.py
@@ -1,7 +1,7 @@
 from junjo.node import Node
 from loguru import logger
 
-from app.ai_services.grok import GrokTool
+from app.ai_services.gemini.gemini_tool import GeminiTool
 from app.workflows.test_sub_flow.store import TestSubFlowStore
 
 
@@ -13,11 +13,11 @@ class SubFlowNode3(Node[TestSubFlowStore]):
         prompt = 'Output a joke about New York City Hotdogs prepended by "SubFlowNode3:"'
         logger.info(f"Prompt: {prompt}")
 
-        grok_tool = GrokTool(prompt=prompt, model="grok-4-1-fast-non-reasoning")
-        grok_result = await grok_tool.text_request()
-        logger.info(f"Grok result: {grok_result}")
+        gemini_tool = GeminiTool(prompt=prompt, model="gemini-3-flash-preview")
+        gemini_result = await gemini_tool.text_request()
+        logger.info(f"Gemini result: {gemini_result}")
 
         # Update state
-        await store.append_joke(grok_result)
+        await store.append_joke(gemini_result)
 
         return

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "junjo"
-version = "0.62.0"
+version = "0.62.1"
 description = "AI graph workflow and state machine framework for building debuggable AI Agents."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -1287,7 +1287,7 @@ wheels = [
 
 [[package]]
 name = "junjo"
-version = "0.62.0"
+version = "0.62.1"
 source = { editable = "." }
 dependencies = [
     { name = "grpcio" },


### PR DESCRIPTION
## Summary
- restore direct Gemini node usage in the AI Chat example workflows
- bump Junjo version to 0.62.1
- add changelog entry for 0.62.1 and sync uv lock version

## Notes
- this is a patch release focused on examples/ai_chat
