### PR TITLE
Clarify post-merge cutover operations

### DIFF
--- a/docs/roadmaps/MONOREPO_GITHUB_CUTOVER_RUNBOOK.md
+++ b/docs/roadmaps/MONOREPO_GITHUB_CUTOVER_RUNBOOK.md
@@ -10,6 +10,11 @@ checks, environments, credentials, PyPI trusted publishing, Docker Hub,
 deployment-distribution mirrors, Cloudflare Pages, old-repository shutdown,
 verification, and forward recovery.
 
+The repository is merged. Operators should begin at
+[Gate B](#gate-b-replace-external-control-plane-configuration). Detailed
+sections above that checklist explain the purpose, exact provider UI location,
+change, and verification for every remaining item.
+
 Do not treat a checked box as evidence by itself. Record the exact workflow run,
 deployment, release, commit, image digest, or settings snapshot in
 `MONOREPO_MIGRATION_RECORD.md`.
@@ -58,8 +63,8 @@ Snapshot date: 2026-07-13.
 - required checks named `required` and `Gitleaks Scan`;
 - no repository rulesets.
 
-The migration branch contains the new monorepo workflows, but they are not
-active as default-branch workflows until merged.
+The new monorepo workflows are active on `master` after merge commit
+`02f34073ceb40963e716498cf2caaaddafa2db28`.
 
 The public Docker Hub repository API currently reports immutable tags disabled
 on the backend, frontend, and ingestion repositories (`enabled: false`, retained
@@ -106,112 +111,186 @@ must be updated for the monorepo. GitHub Pages is not the deployment target.
 
 ## Target GitHub Environments
 
-### `pypi`
+GitHub environments are not servers and they do not deploy anything by
+themselves. They are named security boundaries used by the workflows in
+`.github/workflows`. An environment answers two questions:
 
-Purpose: publish the Python SDK through PyPI Trusted Publishing.
+1. which release refs may run a production job; and
+2. which credentials that job may read.
 
-- Stored secrets: none.
-- Required workflow permission: `id-token: write` on the publish job only.
-- Allowed ref: `sdk-python-v*` tags.
-- PyPI publisher identity:
-  - owner: `mdrideout`
-  - repository: `junjo`
-  - workflow filename: `python-publish.yml`
-  - environment: `pypi`
+Open the destination repository and navigate to **Settings > Environments**:
 
-The old trusted-publisher workflow filename was `publish.yml`. Update the PyPI
-publisher before the next package release.
+<https://github.com/mdrideout/junjo/settings/environments>
 
-### `studio-dockerhub-production`
+The four required environments and their tag policies already exist. Their
+credential stores are empty after the merge. Populate only the two environments
+that need external credentials:
 
-Purpose: publish Studio images, manifests, and Docker Hub descriptions.
+| Environment | Why it exists | What the operator changes |
+| --- | --- | --- |
+| `studio-dockerhub-production` | Allows Studio release jobs to push the three production images. | Add two Docker Hub secrets and, after disabling the old publisher, one authority variable. |
+| `studio-distributions-production` | Allows the release job to replace the contents of the two generated deployment-mirror repositories. | Add a narrowly installed GitHub App ID and private key. |
+| `studio-release-production` | Separates final GitHub Release creation from image and mirror publication. | Nothing. It deliberately has no secrets. |
+| `pypi` | Binds PyPI's short-lived OIDC token to the Python publishing job. | Nothing in GitHub. Configure the matching publisher on PyPI. |
 
-- Environment secrets:
-  - `DOCKERHUB_USERNAME`
-  - `DOCKERHUB_TOKEN`
-- Environment variable:
-  - `STUDIO_RELEASE_AUTHORITY_CUTOVER=mdrideout/junjo`
-- Allowed ref: `studio-v*` tags.
-- Jobs: release-authority and live immutable-rule preflight, image architecture
-  push, manifest creation/promotion, and Docker Hub description update only.
+Environment secrets are encrypted credentials. Environment variables are
+non-secret configuration and can appear in logs. Do not put tokens or private
+keys in variables.
 
-Create a new least-privilege Docker Hub token rather than reusing an unknown
-repository-secret value when possible.
+### Configure `studio-dockerhub-production`
 
-Do not create the authority variable until every old Studio release workflow
-and Docker Hub autobuild is disabled. Configure each of the three contract-owned
-Docker Hub repositories with **specific immutable tags** and exactly these Go/RE2
-rules:
+**Purpose:** give only Studio production jobs access to Docker Hub, and prevent
+the monorepo from publishing until the old repository has lost that authority.
 
-- `^[0-9]+\.[0-9]+\.[0-9]+$`
-- `^[0-9a-f]{40}$`
+**Where:** **Junjo repository > Settings > Environments >
+`studio-dockerhub-production`**.
 
-This leaves `major.minor`, `latest`, and run-scoped candidate tags mutable while
-making stable versions and full source revisions registry-enforced write-once
-identities. The production workflow reads the live Docker Hub repository
-settings and fails before its first image mutation if any repository identity,
-enabled flag, or rule differs. See Docker's
-[immutable tags documentation](https://docs.docker.com/docker-hub/repos/manage/hub-images/immutable-tags/).
+**Before adding the authority variable:**
 
-### `studio-distributions-production`
+1. In `mdrideout/junjo-ai-studio`, open **Actions > Publish Docker Images**, use
+   the workflow menu, and choose **Disable workflow**.
+2. In that old repository, open **Settings > Secrets and variables > Actions**
+   and delete `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN`. This makes an accidental
+   re-enable harmless.
+3. In Docker Hub, open each of these repositories and check **Builds > Configure
+   automated builds**. Disable every Autobuild rule:
+   - `mdrideout/junjo-ai-studio-backend`
+   - `mdrideout/junjo-ai-studio-frontend`
+   - `mdrideout/junjo-ai-studio-ingestion`
+4. In each Docker Hub repository, open **Settings > General > Tag mutability
+   settings**, select **Specific tags are immutable**, and add exactly:
+   - `^[0-9]+\.[0-9]+\.[0-9]+$`
+   - `^[0-9a-f]{40}$`
 
-Purpose: publish the minimal and VM/Caddy distributions to their standalone
-repositories.
+The first rule makes stable release versions such as `0.81.2` write-once. The
+second makes full source-commit tags write-once. `latest`, `0.81`, and temporary
+candidate tags remain movable because the release workflow promotes them only
+after verification. Docker documents this control under
+[immutable tags](https://docs.docker.com/docker-hub/repos/manage/hub-images/immutable-tags/).
 
-Preferred authentication is a GitHub App installed only on:
+**Then configure GitHub:**
 
-- `mdrideout/junjo-ai-studio-minimal-build`
-- `mdrideout/junjo-ai-studio-deployment-example`
+1. In Docker Hub, open **Avatar > Account settings > Personal access tokens >
+   Generate new token**. Name it for the Junjo monorepo release workflow, set a
+   deliberate expiration, and choose **Read & Write**. The `mdrideout` namespace
+   is a personal namespace, so Docker PATs are account-scoped rather than
+   repository-scoped; do not grant Delete permission. Docker documents this UI
+   under [personal access tokens](https://docs.docker.com/security/access-tokens/).
+2. Under **Environment secrets**, add:
+   - `DOCKERHUB_USERNAME`: the Docker Hub account name;
+   - `DOCKERHUB_TOKEN`: the new token, not the account password.
+3. Under **Environment variables**, add:
+   - `STUDIO_RELEASE_AUTHORITY_CUTOVER=mdrideout/junjo`
 
-The App receives repository contents write permission and no unrelated account
-permission.
+The authority variable is an intentional circuit breaker. Its value tells the
+workflow that the operator has disabled competing publishers; it is not a
+credential and it does not grant access by itself.
 
-- Environment variable: `JUNJO_MIRROR_APP_ID`
-- Environment secret: `JUNJO_MIRROR_APP_PRIVATE_KEY`
-- Allowed ref: `studio-v*` tags.
+**Verify:** return to the environment page and confirm the two secret *names*
+and one variable are listed. Do not print secret values. The first release also
+queries the public Docker Hub settings and fails before pushing if any immutable
+rule differs from the contract.
 
-The GitHub App is the only supported mirror-publishing identity. The workflow's
-normal `GITHUB_TOKEN` cannot write to other repositories, and personal access
-tokens are not a fallback path.
+### Configure `studio-distributions-production`
 
-### `studio-release-production`
+**Purpose:** allow a release to publish generated copies of the canonical
+deployment directories to two standalone repositories. A normal repository
+`GITHUB_TOKEN` cannot write to other repositories. A dedicated GitHub App gives
+the workflow a short-lived token limited to exactly those mirrors, without
+using a maintainer's personal access token.
 
-Purpose: authorize the final GitHub release after all immutable images,
-deployment mirrors, floating tags, descriptions, and evidence have completed.
+**Where to create the App:** GitHub profile picture > **Settings > Developer
+settings > GitHub Apps > New GitHub App**. A direct starting point is
+<https://github.com/settings/apps>.
 
-- Stored secrets: none.
-- Allowed ref: `studio-v*` tags.
-- Job: final release-evidence validation and GitHub release creation only.
-- Required workflow permission: `contents: write` on that job only.
+Create a private App, for example `junjo-studio-distribution-publisher`, with:
 
-This environment does not grant Docker or mirror credentials. It separates the
-final repository mutation from both external publishing authorities.
+- webhook disabled;
+- repository permission **Contents: Read and write**;
+- no account permissions and no other repository write permissions.
 
-### `studio-live-model-tests`
+After creation:
 
-Purpose: optional provider integration tests that intentionally make live model
-requests.
+1. On the App settings page, note the **App ID**. Do not use the Client ID.
+2. Generate one private key and retain the downloaded PEM only long enough to
+   store it in GitHub.
+3. Choose **Install App**, select **Only select repositories**, and install it
+   on exactly:
+   - `mdrideout/junjo-ai-studio-minimal-build`
+   - `mdrideout/junjo-ai-studio-deployment-example`
+4. Open **Junjo repository > Settings > Environments >
+   `studio-distributions-production`**.
+5. Under **Environment variables**, add `JUNJO_MIRROR_APP_ID` with the numeric
+   App ID.
+6. Under **Environment secrets**, add `JUNJO_MIRROR_APP_PRIVATE_KEY` with the
+   complete PEM file contents, including its begin/end lines.
 
-- Optional secrets:
-  - `OPENAI_API_KEY`
-  - `ANTHROPIC_API_KEY`
-  - `GEMINI_API_KEY`
-- Trigger: manual dispatch or an explicitly approved schedule.
-- Never required for pull-request merge.
-- Never referenced by ordinary Studio, deployment, or Agent deterministic CI.
+GitHub documents the installation scoping under
+[installing your own GitHub App](https://docs.github.com/en/apps/using-github-apps/installing-your-own-github-app)
+and private-key creation under
+[managing GitHub App private keys](https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/managing-private-keys-for-github-apps).
 
-Do not recreate `JUNJO_SESSION_SECRET` or `JUNJO_SECURE_COOKIE_KEY` as GitHub
-secrets for tests. Use fixed, clearly non-production fixture values in CI.
+**Verify:** the App installation page lists only the two mirrors, and the
+environment page lists the variable and secret names. Do not manually edit the
+mirrors after this cutover; `apps/studio/deployments` is canonical.
 
-### `website-staging` and `website-production`
+### Verify `studio-release-production`
 
-The existing Cloudflare Git integration remains the deployment mechanism, so no
-Cloudflare API token is required in GitHub Actions. GitHub runs website build
-validation; Cloudflare creates previews and production deployments.
+**Purpose:** the last workflow job creates the GitHub Release only after image,
+archive, mirror, and provenance evidence succeeds. It uses the job-scoped
+`GITHUB_TOKEN`; no external credential belongs here.
 
-If deployment is deliberately moved to Wrangler later, create a separate ADR
-and use environment-scoped, project-limited Cloudflare credentials. Do not run
-both Git integration and direct-upload production deployment concurrently.
+**Where:** **Junjo repository > Settings > Environments >
+`studio-release-production`**.
+
+Confirm that it allows only `studio-v*` tags and has no secrets or variables.
+No value needs to be added.
+
+### Configure the PyPI trust relationship
+
+**Purpose:** let PyPI issue a short-lived token only to the exact Junjo workflow
+and environment. No permanent PyPI token is stored in GitHub.
+
+**GitHub side:** **Junjo repository > Settings > Environments > `pypi`**. It
+already allows only `sdk-python-v*` tags and must remain empty.
+
+**PyPI side:** sign in to PyPI, open **Your projects > junjo > Manage >
+Publishing**, and add a GitHub Actions trusted publisher with:
+
+- owner: `mdrideout`
+- repository: `junjo`
+- workflow filename: `python-publish.yml`
+- environment: `pypi`
+
+PyPI documents this UI under
+[adding a publisher to an existing project](https://docs.pypi.org/trusted-publishers/adding-a-publisher/).
+After the new publisher appears, remove the obsolete publisher for workflow
+`publish.yml` or the old repository.
+
+**Verify:** PyPI lists the exact four fields above and GitHub's `pypi`
+environment contains no PyPI token.
+
+### GitHub settings that are controls, not credentials
+
+Two remaining repository settings protect the workflow definitions and release
+tags themselves.
+
+1. Open **Junjo repository > Settings > Actions > General**. Under **Actions
+   permissions**, enable **Require actions to be pinned to a full-length commit
+   SHA**. Purpose: a third-party action tag cannot be silently moved to new
+   code. The merged workflows already use full commit SHAs. GitHub documents
+   this under
+   [repository Actions settings](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository).
+2. Open **Junjo repository > Settings > Rules > Rulesets > New ruleset > New tag
+   ruleset**. Name it `immutable-studio-release-tags`, target tags matching
+   `studio-v*`, set enforcement to **Active**, and enable **Restrict updates**
+   and **Restrict deletions**. Do not restrict creation. Purpose: a published
+   release tag remains bound to the source commit used for images and evidence.
+   GitHub documents the UI under
+   [creating repository rulesets](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/creating-rulesets-for-a-repository).
+
+Cloudflare remains the website deployment authority. Do not create GitHub
+website deployment environments or Cloudflare API secrets for this cutover.
 
 ## Repository-Committable Workflow Work
 
@@ -389,16 +468,31 @@ does not make a legal conclusion or approve a release.
 
 ## Cloudflare Pages Cutover
 
-Merge the validated migration before changing Cloudflare. The failing legacy
-Cloudflare check on pull request 12 is not a merge gate because it evaluates the
-new tree with obsolete project settings. No temporary Pages projects, preview
-rehearsal, deployment freeze, or old-project fallback is required. After the
-merge, update both existing Pages projects directly and fix any deployment
-failure forward on `master`.
+**Purpose:** make Cloudflare build both public sites from their canonical
+monorepo directories on `master`. GitHub validates the builds; Cloudflare owns
+hosting, custom domains, and automatic production deployment.
+
+**First grant repository access:** on GitHub, open **Profile picture > Settings
+> Applications > Installed GitHub Apps > Cloudflare Workers and Pages >
+Configure**. Under repository access, ensure `mdrideout/junjo` is selected.
+Without this access Cloudflare cannot clone the monorepo.
+
+Cloudflare permits changing build settings on an existing Pages project, but it
+does not permit changing that project's connected Git repository. Therefore:
+
+- edit `junjo-python-api` in place because it already uses `mdrideout/junjo`;
+- delete and recreate `junjo-website` because it uses the old standalone
+  repository.
+
+There is no temporary project or rollback path. If a deployment fails, fix its
+settings or `master` and deploy forward. Cloudflare documents the repository
+limitation under [Pages known issues](https://developers.cloudflare.com/pages/platform/known-issues/)
+and monorepo roots under [Pages build configuration](https://developers.cloudflare.com/pages/configuration/build-configuration/).
 
 ### Python API documentation
 
-Update the existing `junjo-python-api` Pages project with these settings:
+**Where:** Cloudflare dashboard > **Workers & Pages > `junjo-python-api` >
+Settings > Builds**. Edit the Git/build configuration to:
 
 - repository: `mdrideout/junjo`
 - production branch: `master`
@@ -413,13 +507,27 @@ Update the existing `junjo-python-api` Pages project with these settings:
   - relevant root workflow/tooling paths
 - production custom domain: `python-api.junjo.ai`
 
-Trigger a production deployment and verify the domain, TLS, index, API pages,
-static assets, sitemap, and deep links. If it fails, correct `master` or the
-Pages settings and deploy again.
+Add `PYTHON_VERSION` under **Settings > Environment variables** for both
+production and preview if the UI scopes values by environment. Configure build
+watch paths under **Settings > Builds > Build watch paths**.
+
+**Verify:** trigger **Deployments > Create deployment/Retry deployment**, then
+open `https://python-api.junjo.ai` and at least one deep API-documentation URL.
+Confirm the deployment source is `mdrideout/junjo` `master`, not merely that the
+old cached site still responds.
 
 ### Junjo website
 
-Update the existing `junjo-website` Pages project with these settings:
+The existing project is connected to `mdrideout/junjo-website`, so it cannot be
+edited into the desired state.
+
+**Where and action:**
+
+1. In Cloudflare, open **Workers & Pages > `junjo-website` > Custom domains** and
+   remove `junjo.ai`.
+2. Open **Settings > Delete project** and delete the old project.
+3. Return to **Workers & Pages > Create application > Pages > Connect to Git**.
+4. Select `mdrideout/junjo`, name the project `junjo-website`, and configure:
 
 - repository: `mdrideout/junjo`
 - production branch: `master`
@@ -432,10 +540,15 @@ Update the existing `junjo-website` Pages project with these settings:
   - platform documentation paths intentionally consumed by the site
 - production custom domain: `junjo.ai`
 
-Trigger a production deployment and verify the domain, TLS, redirects, assets,
-sitemap, robots, and deep links. Disconnect the old
-`mdrideout/junjo-website` integration; if the new deployment fails, correct the
-monorepo or Pages settings and deploy again.
+5. Add `NODE_VERSION` under **Settings > Environment variables** for production
+   and preview if scoped separately.
+6. Configure the include paths under **Settings > Builds > Build watch paths**.
+7. Allow the first production deployment to complete, then add `junjo.ai` under
+   **Custom domains**.
+
+**Verify:** open `https://junjo.ai`, `/sitemap-index.xml`, `/robots.txt`, and at
+least one deep documentation route. In the Cloudflare deployment details,
+confirm the source is `mdrideout/junjo` `master` and the root is `apps/website`.
 
 ## PyPI Trusted Publisher Cutover
 
@@ -501,59 +614,92 @@ request commit.
 - [x] Record the license holder's confirmed Tailwind UI/Plus purchase and
   historical Studio end-product use; retain the imported commits and tags under
   their applicable historical licenses as decided by ADR 0002.
-- [ ] Merge pull request 12 with a merge commit, not squash or rebase.
-- [ ] Verify required checks on `master`.
+- [x] Merge pull request 12 with merge commit
+  `02f34073ceb40963e716498cf2caaaddafa2db28`.
+- [x] All component workflows triggered by merge commit `02f3407` completed on
+  `master`, including Gitleaks, Platform Integrity, Python, website, telemetry,
+  Studio backend/ingestion/frontend/deployments, version sync, Proto, and REST.
 
-The obsolete Cloudflare pull-request check is explicitly non-blocking. Merge is
-the first remaining operator action.
+The repository merge is complete. Start Gate B below.
 
 ### Gate B: Replace external control-plane configuration
 
-- [x] Configure GitHub environments and ref policies.
-- [ ] Recreate/rotate only approved environment credentials.
-- [ ] Disable every old Studio release workflow and Docker Hub autobuild, remove
-  its Docker publishing authority, and record the settings evidence.
-- [ ] Configure and verify the two contract-owned Docker Hub immutable-tag
-  rules on the backend, frontend, and ingestion repositories.
-- [ ] Only after those two checks, set
-  `STUDIO_RELEASE_AUTHORITY_CUTOVER=mdrideout/junjo` in
-  `studio-dockerhub-production`.
-- [ ] Configure PyPI trusted publisher.
-- [ ] Install the mirror GitHub App on exactly two repositories.
-- [ ] Reconfigure both existing Cloudflare Pages projects directly against
-  `mdrideout/junjo` `master` using the component roots above.
-- [x] Verify required checks are exactly `required` and `Gitleaks Scan` after
-  their stable contexts exist.
-- [ ] Enable repository action-SHA enforcement after the merged workflow set is
-  present and record the settings response.
-- [ ] Add and verify an immutable `studio-v*` tag ruleset, or record the exact
-  GitHub plan/API limitation that prevents it.
+Complete these controls before creating the first `studio-v0.81.2` tag. Each
+item links to the detailed purpose, location, action, and verification above.
+
+- [x] GitHub environments and tag policies exist. This only creates empty
+  security boundaries; it does not provide credentials or enable publishing.
+- [ ] [Transfer Docker publishing authority](#configure-studio-dockerhub-production):
+  disable the old `Publish Docker Images` workflow, delete its Docker secrets,
+  disable Docker Hub Autobuilds, configure both immutable-tag rules on all three
+  image repositories, add new environment credentials, then add the authority
+  variable last.
+- [ ] [Create and install the mirror GitHub App](#configure-studio-distributions-production),
+  then store its App ID and private key in the distributions environment.
+- [ ] [Configure PyPI Trusted Publishing](#configure-the-pypi-trust-relationship)
+  for the next Python release. This is independent of the Studio release and
+  does not require a GitHub secret.
+- [ ] [Enable action SHA pinning and create the Studio tag ruleset](#github-settings-that-are-controls-not-credentials).
+- [ ] [Reconfigure Cloudflare](#cloudflare-pages-cutover): edit Python docs in
+  place, delete/recreate the website project from the monorepo, and verify both
+  production domains.
+- [x] Required pull-request checks are exactly `required` and `Gitleaks Scan`.
 
 ### Gate C: Publish and verify
 
-- [ ] Verify both Cloudflare production projects.
-- [ ] Perform the first destination Studio release.
-- [ ] Verify exact image manifests and digests.
-- [ ] Verify both release archives from clean extraction.
-- [ ] Verify both mirrors from fresh clones.
-- [ ] Verify generated-source SHAs and tree digests.
-- [ ] Perform the next Python release.
+- [ ] Confirm both Cloudflare deployment-detail pages identify
+  `mdrideout/junjo` `master` and the correct component root.
+- [ ] From an up-to-date local `master`, create and push the first Studio release
+  tag. The version is read from `apps/studio/VERSION`:
+
+  ```bash
+  git switch master
+  git pull --ff-only origin master
+  VERSION="$(cat apps/studio/VERSION)"
+  test "$VERSION" = "0.81.2"
+  git tag -a "studio-v${VERSION}" -m "Junjo AI Studio ${VERSION}"
+  git push origin "studio-v${VERSION}"
+  ```
+
+  The tag starts `.github/workflows/studio-docker-publish.yml`; do not manually
+  run the workflow for a production release.
+- [ ] In **Junjo repository > Actions > Publish Studio Release**, wait for the
+  entire run. If it fails, correct the cause and use **Re-run all jobs**. Never
+  use **Re-run failed jobs**, because production evidence is bound to one fresh
+  workflow attempt.
+- [ ] Open the resulting GitHub Release and verify it contains image digests,
+  archive hashes, source SHA, mirror commits, and release evidence.
+- [ ] In Docker Hub, verify `0.81.2` and the full source SHA resolve to the
+  recorded immutable manifests, and `0.81`/`latest` resolve to the promoted
+  release.
+- [ ] Fresh-clone both mirror repositories and verify their generated-source
+  notices identify the release source SHA and canonical monorepo path.
+- [ ] For the next Python SDK release, update the version on `master`, publish a
+  GitHub Release whose tag is exactly `sdk-python-v<pyproject version>`, and
+  verify **Actions > Publish Python SDK to PyPI** and the PyPI project page.
 
 ### Gate D: Retire competing sources
 
-- [ ] Update the old website default branch with Apache-2.0 and a
-  canonical-source/archive notice.
-- [ ] Update the old Studio default branch with a canonical-source/archive
-  notice that preserves the Tailwind Plus boundary; do not relabel retained
+After the Studio and website cutovers are proven, retire repositories that could
+be mistaken for editable source. There is no observation or rollback period.
+
+- [ ] In `mdrideout/junjo-ai-studio`, commit a short canonical-source/archive
+  notice that points to `mdrideout/junjo/apps/studio` and preserves the
+  historical Tailwind Plus boundary. Do not relabel historical
   Catalyst-derived source as Apache-2.0.
-- [ ] Disable every remaining non-release old Studio workflow.
-- [ ] Delete remaining old Studio repository secrets.
-- [ ] Archive the old Studio source repository.
-- [ ] Disconnect and archive the old website source repository.
-- [ ] Keep both deployment repositories unarchived as generated distributions.
-- [ ] Keep the minimal repository as a template.
-- [ ] Decide and record whether VM/Caddy is also a template.
-- [ ] Redirect contribution instructions and issues to the monorepo.
+- [ ] Open **old Studio repository > Actions** and disable every remaining
+  workflow. Open **Settings > Secrets and variables > Actions** and delete every
+  remaining secret. Then open **Settings > General > Danger Zone > Archive this
+  repository**.
+- [ ] In `mdrideout/junjo-website`, commit Apache-2.0 and a canonical-source
+  notice pointing to `mdrideout/junjo/apps/website`. Then open **Settings >
+  General > Danger Zone > Archive this repository**.
+- [ ] Keep `mdrideout/junjo-ai-studio-minimal-build` and
+  `mdrideout/junjo-ai-studio-deployment-example` unarchived. They are generated
+  release distributions, not editable sources. Keep the minimal repository as
+  a GitHub template and decide whether VM/Caddy should also be a template.
+- [ ] Point contribution and issue links in all retained repositories to
+  `mdrideout/junjo`.
 
 ## GitHub Settings Evidence Commands
 

--- a/docs/roadmaps/MONOREPO_MIGRATION_PLAN.md
+++ b/docs/roadmaps/MONOREPO_MIGRATION_PLAN.md
@@ -2,9 +2,9 @@
 
 ## Status
 
-Source consolidation and repository remediation are complete. The final branch
-revision is pushed, required pull-request checks passed, and pull request 12 is
-ready for a history-preserving merge commit.
+Source consolidation and repository remediation are complete. Pull request 12
+merged with history preserved at
+`02f34073ceb40963e716498cf2caaaddafa2db28` on 2026-07-13.
 
 - The Python SDK and Junjo AI Studio source migration was completed on the
   `codex/platform-monorepo-migration` branch on 2026-07-12.
@@ -26,8 +26,9 @@ The implemented fixes and remaining completion gates are defined in
 by the license holder's confirmed Tailwind UI/Plus purchase and application
 end-product use. Required pull-request checks are complete. Credentials,
 publishing, hosting, and old-repository retirement remain explicit cutover
-work. The legacy Cloudflare pull-request check is not a merge gate; Cloudflare
-is reconfigured directly after merge.
+work. The Python docs Cloudflare project is edited in place; the website Pages
+project is deleted/recreated because Cloudflare cannot change the repository of
+an existing Git-integrated project.
 
 ADR 0001 defines the accepted end state. This plan records how the repository
 was moved to that state without mixing runtime refactors into the structural

--- a/docs/roadmaps/MONOREPO_MIGRATION_RECORD.md
+++ b/docs/roadmaps/MONOREPO_MIGRATION_RECORD.md
@@ -6,15 +6,13 @@ This record proves the completed source imports and records local repository
 remediation evidence for
 the Python SDK, Studio, website, minimal Studio distribution, and VM/Caddy
 distribution. The fixes required by
-`MONOREPO_MIGRATION_REMEDIATION_PLAN.md` are implemented on
-`codex/platform-monorepo-migration`. Final pull-request evidence is recorded
-below; the branch is ready to merge.
+`MONOREPO_MIGRATION_REMEDIATION_PLAN.md` were merged by pull request 12 as merge
+commit `02f34073ceb40963e716498cf2caaaddafa2db28` on 2026-07-13.
 
-This does not claim that the migration has merged or that production cutover is
-complete. Merge, credentials, trusted publishing, direct hosting cutover, first
-production releases, and old-repository retirement remain operator work. The
-legacy Cloudflare pull-request failure is not a merge gate. Historical Catalyst
-rights are resolved by the license holder confirmation recorded below.
+Production cutover is not complete. Credentials, trusted publishing, direct
+hosting cutover, first production releases, and old-repository retirement
+remain operator work. Historical Catalyst rights are resolved by the license
+holder confirmation recorded below.
 
 Production mirror publication, hosting cutover, environment credentials,
 trusted-publisher changes, action-SHA enforcement, the immutable release-tag
@@ -65,22 +63,28 @@ all three Studio repositories on 2026-07-13. The implemented production
 workflow will fail before registry mutation until Gate B installs the two exact
 contract rules and records this monorepo as the exclusive publisher.
 
-## Final pull-request evidence
+## Final pull-request and merge evidence
 
-Pull request 12 is repository-complete and ready to merge:
+Pull request 12 merged with history preserved:
 
-- final reviewed head: `afc5db6df948e6197bad3231a498b9fdcd7a99c7`;
-- Platform Gate run
-  `https://github.com/mdrideout/junjo/actions/runs/29258647990` passed every
+- final pull-request head:
+  `3f8e5b32f52257e62044f178d197c359974407e8`;
+- final Platform Gate run
+  `https://github.com/mdrideout/junjo/actions/runs/29264365485` passed every
   routed component, both-architecture dry build, release rehearsal, and local
   telemetry smoke;
-- Gitleaks run
-  `https://github.com/mdrideout/junjo/actions/runs/29258647436` passed;
-- the branch is mergeable and synchronized with its remote;
+- final Gitleaks run
+  `https://github.com/mdrideout/junjo/actions/runs/29264364485` passed;
+- pull request 12 merged at
+  `02f34073ceb40963e716498cf2caaaddafa2db28` on 2026-07-13;
+- every component workflow triggered on that `master` merge commit completed
+  successfully, including deployment validation run
+  `https://github.com/mdrideout/junjo/actions/runs/29269170458` and Gitleaks run
+  `https://github.com/mdrideout/junjo/actions/runs/29269171102`;
 - the only non-green check is the legacy Cloudflare Pages integration using
   obsolete pre-monorepo build settings. Production downtime and preview
   continuity are not migration requirements, so that check is intentionally
-  non-blocking and Cloudflare is reconfigured directly after merge.
+  non-blocking and Cloudflare is reconfigured after merge.
 
 ## Source revisions
 

--- a/docs/roadmaps/MONOREPO_MIGRATION_REMEDIATION_PLAN.md
+++ b/docs/roadmaps/MONOREPO_MIGRATION_REMEDIATION_PLAN.md
@@ -2,17 +2,16 @@
 
 ## Status
 
-Repository remediation is implemented, pushed, and validated on
-`codex/platform-monorepo-migration` as of 2026-07-13. The accepted ADRs,
+Repository remediation was implemented, validated, and merged by pull request
+12 at `02f34073ceb40963e716498cf2caaaddafa2db28` on 2026-07-13. The accepted ADRs,
 Junjo-owned Base UI foundation, release transaction, deployment proof, CI
 routing, secret scanning, license metadata, repository-owned validation, and
 immutable workflow evidence are recorded in `MONOREPO_MIGRATION_RECORD.md`.
 
-Pull request 12 is repository-complete at revision `afc5db6`: Platform Gate and
-Gitleaks passed. The legacy Cloudflare check uses obsolete project settings and
-is explicitly not a merge gate. Merge is the next action; credentials, trusted
-publishing, direct hosting reconfiguration, first releases, and old repository
-retirement follow from `MONOREPO_GITHUB_CUTOVER_RUNBOOK.md`.
+The final pull-request revision `3f8e5b3` passed Platform Gate and Gitleaks.
+Credentials, trusted publishing, direct hosting reconfiguration, first
+releases, and old repository retirement are the remaining operator work in
+`MONOREPO_GITHUB_CUTOVER_RUNBOOK.md`.
 
 No production tag, mirror publication, repository archival, or Cloudflare
 source cutover may occur before its corresponding cutover gate passes.
@@ -635,10 +634,13 @@ direct jobs.
   is present, then record the settings response.
 - Release the next Python version according to the Python release plan.
 - Prepare Studio `0.81.2` or later; never reuse `0.81.1`.
-- Apply the monorepo Cloudflare settings directly to the existing production
-  projects after merge:
-  - Python docs source `sdks/python`, output `docs/_build/html`;
-  - website source `apps/website`, output `dist`.
+- Apply the monorepo Cloudflare settings after merge:
+  - edit the existing Python docs project because it already uses
+    `mdrideout/junjo`, with source `sdks/python` and output
+    `docs/_build/html`;
+  - delete/recreate the website Pages project from `mdrideout/junjo` because
+    Cloudflare cannot change the connected repository on an existing
+    Git-integrated project, with source `apps/website` and output `dist`.
 - Verify exact image digests, source-SHA tags, distribution archives, mirror
   repository/branch/commit/tree, release evidence, and GitHub release assets.
 - Verify the deployed website and Python docs from their canonical monorepo


### PR DESCRIPTION
## Summary

- explain what each GitHub environment controls and why it exists
- provide exact GitHub, Docker Hub, PyPI, and Cloudflare UI locations and verification criteria
- correct the Cloudflare website cutover to delete/recreate the Git-integrated project
- record PR 12 merge evidence and successful master validation
- make the remaining release and repository-retirement sequence explicit

## Validation

- `git diff --check`
- `python3 tooling/scripts/validate_repository.py`