### PR TITLE
Wait for Docker Hub floating-tag convergence

### DIFF
--- a/.github/workflows/studio-docker-publish.yml
+++ b/.github/workflows/studio-docker-publish.yml
@@ -577,10 +577,20 @@ jobs:
               docker buildx imagetools create \
                 -t "$IMAGE:$tag" \
                 "$IMAGE@$VERSION_DIGEST"
-              PROMOTED_DIGEST="$(
-                docker buildx imagetools inspect "$IMAGE:$tag" |
-                  sed -n 's/^Digest:[[:space:]]*//p'
-              )"
+              PROMOTED_DIGEST=""
+              for attempt in $(seq 1 15); do
+                PROMOTED_DIGEST="$(
+                  docker buildx imagetools inspect "$IMAGE:$tag" |
+                    sed -n 's/^Digest:[[:space:]]*//p'
+                )"
+                if [ "$PROMOTED_DIGEST" = "$VERSION_DIGEST" ]; then
+                  break
+                fi
+                if [ "$attempt" -lt 15 ]; then
+                  echo "Waiting for $IMAGE:$tag to converge to $VERSION_DIGEST (attempt $attempt/15)."
+                  sleep 2
+                fi
+              done
               if [ "$PROMOTED_DIGEST" != "$VERSION_DIGEST" ]; then
                 echo "$IMAGE:$tag does not resolve to the exact release digest." >&2
                 exit 1

--- a/tooling/tests/test_ci_release_tools.py
+++ b/tooling/tests/test_ci_release_tools.py
@@ -404,6 +404,7 @@ class StudioReleasePolicyTests(unittest.TestCase):
             workflow.index("Validate live Docker Hub immutable-tag controls"),
             workflow.index("Build and push architecture image by digest"),
         )
+
         mirror_preflight = workflow.index(
             "Validate all mirror destinations before minting mutation credentials"
         )
@@ -432,6 +433,16 @@ class StudioReleasePolicyTests(unittest.TestCase):
             self.assertIn(f"/tmp/junjo-release/{filename}", evidence_upload)
         self.assertNotIn("mirror-preflight.json", evidence_upload)
         self.assertNotIn("mirror-authorized-preflight.json", evidence_upload)
+
+    def test_floating_tag_verification_waits_for_registry_convergence(self) -> None:
+        workflow = (
+            REPOSITORY_ROOT / ".github/workflows/studio-docker-publish.yml"
+        ).read_text(encoding="utf-8")
+        self.assertIn("for attempt in $(seq 1 15)", workflow)
+        self.assertIn(
+            'if [ "$PROMOTED_DIGEST" = "$VERSION_DIGEST" ]; then', workflow
+        )
+        self.assertIn("sleep 2", workflow)
 
 
 class MirrorTreeTests(unittest.TestCase):


### PR DESCRIPTION
Docker Hub can briefly return the previous digest immediately after a successful mutable-tag update. The 0.81.3 release exposed that read-after-write race on `latest`.

This change keeps the exact same fail-closed digest check but polls for up to 30 seconds before declaring promotion unsuccessful.

Validation:
- release policy tests
- repository invariants
- staged Gitleaks scan