### PR TITLE
Let Cloudflare build unified documentation from validated source

### DIFF
--- a/.github/workflows/website-ci.yml
+++ b/.github/workflows/website-ci.yml
@@ -1,4 +1,4 @@
-name: Public Documentation
+name: Public Documentation Validation
 
 on:
   push:
@@ -15,16 +15,6 @@ on:
       - ".github/workflows/website-ci.yml"
   pull_request:
     branches: [master]
-    paths:
-      - "apps/website/**"
-      - "apps/studio/docs/**"
-      - "apps/studio/deployments/**"
-      - "sdks/python/**"
-      - "contracts/telemetry/README.md"
-      - "docs/adr/**"
-      - "docs/roadmaps/**"
-      - "tooling/docs/**"
-      - ".github/workflows/website-ci.yml"
   workflow_dispatch:
     inputs:
       documentation_channel:
@@ -45,8 +35,44 @@ permissions:
   contents: read
 
 jobs:
+  changes:
+    name: Public documentation scope
+    runs-on: ubuntu-latest
+    outputs:
+      docs_changed: ${{ steps.scope.outputs.docs_changed }}
+    steps:
+      - name: Checkout source history
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Detect public documentation changes
+        id: scope
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.sha }}
+        run: |
+          docs_changed=true
+          if [[ "$EVENT_NAME" == "pull_request" ]]; then
+            docs_changed=false
+            while IFS= read -r path; do
+              case "$path" in
+                apps/website/* | apps/studio/docs/* | apps/studio/deployments/* | \
+                sdks/python/* | contracts/telemetry/README.md | docs/adr/* | \
+                docs/roadmaps/* | tooling/docs/* | .github/workflows/website-ci.yml)
+                  docs_changed=true
+                  break
+                  ;;
+              esac
+            done < <(git diff --name-only "$BASE_SHA" "$HEAD_SHA")
+          fi
+          echo "docs_changed=$docs_changed" >> "$GITHUB_OUTPUT"
+
   website:
-    name: Unified documentation artifact
+    name: Unified documentation source
+    needs: changes
+    if: needs.changes.outputs.docs_changed == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     env:
@@ -104,69 +130,19 @@ jobs:
       - name: Audit production dependencies
         run: npm audit --omit=dev --audit-level=high
         working-directory: apps/website
-      - name: Upload exact public documentation artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
-        with:
-          name: public-documentation-${{ env.JUNJO_DOCS_CHANNEL }}-${{ github.sha }}
-          path: apps/website/dist
-          if-no-files-found: error
-          retention-days: 14
-      - name: Upload retired legacy-domain redirect site
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
-        with:
-          name: python-api-retirement-${{ github.sha }}
-          path: apps/website/.docs-assembly/python-api-site
-          if-no-files-found: error
-          retention-days: 14
 
-  deploy:
-    name: Deploy unified documentation
-    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
-    needs: website
+  validation:
+    name: Public documentation
+    if: always()
+    needs: [changes, website]
     runs-on: ubuntu-latest
-    timeout-minutes: 10
-    concurrency:
-      group: public-documentation-production
-      cancel-in-progress: false
-    environment:
-      name: public-documentation-production
-      url: https://junjo.ai/
-    permissions:
-      contents: read
-      deployments: write
-    env:
-      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
     steps:
-      - name: Set up Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
-        with:
-          node-version: "22.12"
-      - name: Download exact public documentation artifact
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
-        with:
-          name: public-documentation-next-${{ github.sha }}
-          path: .deployment/public-documentation
-      - name: Download retired legacy-domain redirect site
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
-        with:
-          name: python-api-retirement-${{ github.sha }}
-          path: .deployment/python-api-retirement
-      - name: Deploy exact unified documentation artifact
-        run: >-
-          npx --yes wrangler@4.111.0 pages deploy
-          "$GITHUB_WORKSPACE/.deployment/public-documentation"
-          --project-name=junjo-website
-          --branch=master
-          --commit-hash="$GITHUB_SHA"
-          --commit-message="Unified documentation $GITHUB_SHA"
-          --commit-dirty=false
-      - name: Retire legacy Python API documentation site
-        run: >-
-          npx --yes wrangler@4.111.0 pages deploy
-          "$GITHUB_WORKSPACE/.deployment/python-api-retirement"
-          --project-name=junjo-python-api
-          --branch=master
-          --commit-hash="$GITHUB_SHA"
-          --commit-message="Retire Python API documentation $GITHUB_SHA"
-          --commit-dirty=false
+      - name: Enforce scoped validation result
+        env:
+          DOCS_CHANGED: ${{ needs.changes.outputs.docs_changed }}
+          WEBSITE_RESULT: ${{ needs.website.result }}
+        run: |
+          if [[ "$DOCS_CHANGED" == "true" && "$WEBSITE_RESULT" != "success" ]]; then
+            echo "Public documentation changed but full validation did not pass."
+            exit 1
+          fi

--- a/.github/workflows/website-ci.yml
+++ b/.github/workflows/website-ci.yml
@@ -111,11 +111,62 @@ jobs:
           path: apps/website/dist
           if-no-files-found: error
           retention-days: 14
-      - name: Upload reversible legacy-domain redirect artifact
+      - name: Upload retired legacy-domain redirect site
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
-          name: python-api-redirects-${{ github.sha }}
-          path: apps/website/.docs-assembly/python-api._redirects
+          name: python-api-retirement-${{ github.sha }}
+          path: apps/website/.docs-assembly/python-api-site
           if-no-files-found: error
-          include-hidden-files: true
           retention-days: 14
+
+  deploy:
+    name: Deploy unified documentation
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    needs: website
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    concurrency:
+      group: public-documentation-production
+      cancel-in-progress: false
+    environment:
+      name: public-documentation-production
+      url: https://junjo.ai/
+    permissions:
+      contents: read
+      deployments: write
+    env:
+      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+    steps:
+      - name: Set up Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: "22.12"
+      - name: Download exact public documentation artifact
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: public-documentation-next-${{ github.sha }}
+          path: .deployment/public-documentation
+      - name: Download retired legacy-domain redirect site
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: python-api-retirement-${{ github.sha }}
+          path: .deployment/python-api-retirement
+      - name: Deploy exact unified documentation artifact
+        run: >-
+          npx --yes wrangler@4.111.0 pages deploy
+          "$GITHUB_WORKSPACE/.deployment/public-documentation"
+          --project-name=junjo-website
+          --branch=master
+          --commit-hash="$GITHUB_SHA"
+          --commit-message="Unified documentation $GITHUB_SHA"
+          --commit-dirty=false
+      - name: Retire legacy Python API documentation site
+        run: >-
+          npx --yes wrangler@4.111.0 pages deploy
+          "$GITHUB_WORKSPACE/.deployment/python-api-retirement"
+          --project-name=junjo-python-api
+          --branch=master
+          --commit-hash="$GITHUB_SHA"
+          --commit-message="Retire Python API documentation $GITHUB_SHA"
+          --commit-dirty=false

--- a/.gitignore
+++ b/.gitignore
@@ -76,7 +76,6 @@ apps/website/src/content/docs/generated/
 apps/website/public/docs-assets/generated/
 apps/website/public/docs-manifests/generated/
 apps/website/.docs-assembly/
-apps/website/.wrangler/
 
 # PyBuilder
 .pybuilder/

--- a/.gitignore
+++ b/.gitignore
@@ -76,6 +76,7 @@ apps/website/src/content/docs/generated/
 apps/website/public/docs-assets/generated/
 apps/website/public/docs-manifests/generated/
 apps/website/.docs-assembly/
+apps/website/.wrangler/
 
 # PyBuilder
 .pybuilder/

--- a/apps/website/AGENTS.md
+++ b/apps/website/AGENTS.md
@@ -32,4 +32,6 @@ npm audit --omit=dev --audit-level=high
 ```
 
 The production artifact is `apps/website/dist`. GitHub Actions assembles and
-validates the exact artifact deployed to Cloudflare Pages.
+validates source without retaining or deploying an artifact. After an approved
+merge, Cloudflare Pages pulls the protected `master` source, repeats the
+version-controlled build contract, and deploys its own generated output.

--- a/apps/website/README.md
+++ b/apps/website/README.md
@@ -45,18 +45,18 @@ the completed production build.
 
 This component deliberately keeps its own `package-lock.json`; it is not part
 of a repository-wide JavaScript workspace. CI installs each documentation
-producer with its own lock, assembles one exact artifact, and publishes only
-`apps/website/dist`. A second deployable directory,
-`.docs-assembly/python-api-site`, contains the global permanent redirect used
-to retire `python-api.junjo.ai`. It belongs only on the `junjo-python-api`
-Cloudflare Pages project and must never be deployed on `junjo.ai`.
+producer with its own lock and validates the complete source assembly without
+retaining or deploying its generated output. After the validated pull request
+is merged, Cloudflare Pages pulls the protected `master` commit and runs
+`tooling/docs/build_cloudflare_pages.sh` from the repository root. Cloudflare
+publishes its own generated `apps/website/dist`; that directory is never
+checked in.
 
-On a successful `master` build, GitHub Actions downloads the exact retained
-artifacts and deploys `dist` to `junjo-website` before deploying the retirement
-artifact to `junjo-python-api`. The `public-documentation-production` GitHub
-environment owns the Cloudflare account ID and least-privilege Pages API token.
-Cloudflare automatic Git deployments are disabled on both Pages projects;
-production is never rebuilt independently from source in two places.
+`legacy-python-api/_redirects` is source configuration, not generated site
+output. The `junjo-python-api` Cloudflare Pages project pulls that directory
+from Git after the same approved merge. Its build waits for the unified Python
+landing page to be live before publishing the single permanent redirect rule.
+It must never be included in the `junjo.ai` output.
 
 CI labels ordinary source builds as `next`. A caller may request the `stable`
 channel only from the exact released checkout; the channel, SDK version, and

--- a/apps/website/README.md
+++ b/apps/website/README.md
@@ -46,10 +46,17 @@ the completed production build.
 This component deliberately keeps its own `package-lock.json`; it is not part
 of a repository-wide JavaScript workspace. CI installs each documentation
 producer with its own lock, assembles one exact artifact, and publishes only
-`apps/website/dist`. Assembly also emits the separately uploaded
-`.docs-assembly/python-api._redirects` compatibility artifact. That redirect
-file belongs only on the legacy `python-api.junjo.ai` project after the
-parallel-run gate; it must never be deployed on `junjo.ai`.
+`apps/website/dist`. A second deployable directory,
+`.docs-assembly/python-api-site`, contains the global permanent redirect used
+to retire `python-api.junjo.ai`. It belongs only on the `junjo-python-api`
+Cloudflare Pages project and must never be deployed on `junjo.ai`.
+
+On a successful `master` build, GitHub Actions downloads the exact retained
+artifacts and deploys `dist` to `junjo-website` before deploying the retirement
+artifact to `junjo-python-api`. The `public-documentation-production` GitHub
+environment owns the Cloudflare account ID and least-privilege Pages API token.
+Cloudflare automatic Git deployments are disabled after direct upload is
+activated; production is never rebuilt independently from source in two places.
 
 CI labels ordinary source builds as `next`. A caller may request the `stable`
 channel only from the exact released checkout; the channel, SDK version, and

--- a/apps/website/README.md
+++ b/apps/website/README.md
@@ -55,8 +55,8 @@ On a successful `master` build, GitHub Actions downloads the exact retained
 artifacts and deploys `dist` to `junjo-website` before deploying the retirement
 artifact to `junjo-python-api`. The `public-documentation-production` GitHub
 environment owns the Cloudflare account ID and least-privilege Pages API token.
-Cloudflare automatic Git deployments are disabled after direct upload is
-activated; production is never rebuilt independently from source in two places.
+Cloudflare automatic Git deployments are disabled on both Pages projects;
+production is never rebuilt independently from source in two places.
 
 CI labels ordinary source builds as `next`. A caller may request the `stable`
 channel only from the exact released checkout; the channel, SDK version, and

--- a/apps/website/legacy-python-api/_redirects
+++ b/apps/website/legacy-python-api/_redirects
@@ -1,0 +1,2 @@
+# The Python Sphinx site is retired. All legacy requests enter the unified docs here.
+/* https://junjo.ai/docs/python/ 301

--- a/docs/adr/0009-unified-documentation-publishing.md
+++ b/docs/adr/0009-unified-documentation-publishing.md
@@ -60,9 +60,14 @@ code to generate documentation.
 ### Assembly And Release
 
 - Component-owned export commands run with their own locks and native tools.
-- A root documentation workflow stages the selected outputs, runs the normal
-  website build, validates the complete artifact, and deploys that exact static
-  artifact to Cloudflare Pages.
+- A version-controlled root documentation command stages the selected outputs,
+  runs the normal website build, and validates the complete artifact.
+- GitHub Actions runs that contract as a pull-request validation gate, then
+  discards its generated output. It does not persist or deploy documentation
+  artifacts. Merging the validated source to protected `master` is the
+  production signal. Cloudflare Pages pulls that commit, runs the same contract,
+  and publishes its generated `apps/website/dist` directory. Build output is
+  never checked in.
 - Stable SDK reference pages describe installable releases and record the SDK
   version and source revision.
 - Main-branch SDK output may be published only as an explicitly labeled `next`
@@ -82,7 +87,7 @@ is proven by the cross-component assembly workflow.
 - Sphinx remains warning-strict as a parity and rollback input until narrative,
   API, route, anchor, search, version, and release parity are verified.
 - `python-api.junjo.ai` becomes the approved global retirement redirect only
-  after the exact unified artifact passes its production build gates.
+  after the unified Cloudflare source build passes its production gates.
 - Sphinx dependencies and sources are retired only in a later, explicit
   cutover after the roadmap's completion criteria are satisfied.
 
@@ -91,10 +96,12 @@ is proven by the cross-component assembly workflow.
 The owner approved the production cutover with two explicit changes to the
 initial compatibility plan:
 
-- GitHub Actions is the production builder and deployer. It assembles and
-  validates one immutable `apps/website/dist` artifact, retains it, and direct
-  uploads that exact artifact to the `junjo-website` Cloudflare Pages project.
-  Cloudflare automatic Git builds are disabled at activation.
+- Cloudflare Pages remains the production builder and deployer through its Git
+  integration. The `junjo-website` project pulls the protected `master` commit
+  and runs the version-controlled `tooling/docs/build_cloudflare_pages.sh`
+  contract. GitHub Actions independently validates the pull-request source but
+  neither persists nor deploys its output. Generated `dist` output is never
+  checked in.
 - The public Sphinx deployment is retired with one permanent global redirect:
   every request on `python-api.junjo.ai` returns a `301` to
   `https://junjo.ai/docs/python/`. Page-by-page route and fragment redirects are

--- a/docs/adr/0009-unified-documentation-publishing.md
+++ b/docs/adr/0009-unified-documentation-publishing.md
@@ -2,6 +2,7 @@
 
 - Status: Accepted
 - Date: 2026-07-14
+- Amended: 2026-07-15 (production deployment and legacy-domain retirement)
 - Owners: Junjo platform, SDKs, Studio, and website
 - Supersedes: the documentation publishing and isolated website-build clauses
   of [ADR 0001](0001-junjo-platform-monorepo.md)
@@ -78,12 +79,33 @@ is proven by the cross-component assembly workflow.
   with section-level provenance and parity validation.
 - Existing Python docstrings are parsed as Sphinx style during migration; a
   docstring-style rewrite is a separate decision.
-- Sphinx remains warning-strict and deployable until narrative, API, route,
-  anchor, search, version, and release parity are verified.
-- `python-api.junjo.ai` becomes a compatibility redirect only after the
-  parallel validation and rollback gates pass.
+- Sphinx remains warning-strict as a parity and rollback input until narrative,
+  API, route, anchor, search, version, and release parity are verified.
+- `python-api.junjo.ai` becomes the approved global retirement redirect only
+  after the exact unified artifact passes its production build gates.
 - Sphinx dependencies and sources are retired only in a later, explicit
   cutover after the roadmap's completion criteria are satisfied.
+
+### Production Cutover Amendment (2026-07-15)
+
+The owner approved the production cutover with two explicit changes to the
+initial compatibility plan:
+
+- GitHub Actions is the production builder and deployer. It assembles and
+  validates one immutable `apps/website/dist` artifact, retains it, and direct
+  uploads that exact artifact to the `junjo-website` Cloudflare Pages project.
+  Cloudflare automatic Git builds are disabled at activation.
+- The public Sphinx deployment is retired with one permanent global redirect:
+  every request on `python-api.junjo.ai` returns a `301` to
+  `https://junjo.ai/docs/python/`. Page-by-page route and fragment redirects are
+  intentionally not part of the retirement surface.
+
+This amendment supersedes the roadmap's original page-level compatibility and
+parallel-publication requirements. It does not authorize deleting or rewriting
+the migrated content. The route ledger, API baseline, Sphinx source, and final
+Sphinx artifact remain as migration evidence and rollback inputs. Sphinx may
+continue to run as a warning-strict parity check until a separate cleanup
+removes that validation dependency.
 
 ## Consequences
 
@@ -97,8 +119,9 @@ alone; it is a static assembly of explicitly versioned inputs. That added build
 coordination is accepted because it prevents manually copied API reference and
 keeps stable docs aligned with released packages.
 
-The migration temporarily maintains both Sphinx and Starlight outputs. This is
-intentional risk control, not a permanent compatibility abstraction.
+The migration retains the Sphinx source and final static artifact as recovery
+inputs, but only the unified Starlight site remains a public documentation
+surface after cutover.
 
 ## Rejected Alternatives
 

--- a/docs/roadmaps/MONOREPO_MIGRATION_RECORD.md
+++ b/docs/roadmaps/MONOREPO_MIGRATION_RECORD.md
@@ -176,9 +176,10 @@ The obsolete `publish.yml` publisher was removed.
 - Restored-site commit: `d81fe0b3013310c7ec962c478c6790a0e487ba72`
 - At the time of this consolidation record, Cloudflare Pages built directly
   from `mdrideout/junjo` on `master`. The 2026-07-15 amendment to ADR 0009
-  supersedes that publishing path: GitHub Actions now owns the exact validated
-  direct-upload artifact. Automatic production and preview deployments are
-  disabled on both Cloudflare Pages projects.
+  keeps that ownership model while making the monorepo build explicit: GitHub
+  Actions validates pull-request source without retaining an artifact, and
+  Cloudflare pulls validated `master`, repeats the version-controlled build,
+  and deploys its own output. Cloudflare preview builds are disabled.
 
 The restored site preserves the original Starlight homepage and documentation
 content. The temporary migration redesign, gradients, replacement copy, and

--- a/docs/roadmaps/MONOREPO_MIGRATION_RECORD.md
+++ b/docs/roadmaps/MONOREPO_MIGRATION_RECORD.md
@@ -156,8 +156,9 @@ both passed before merge.
   - `junjo-0.64.0.tar.gz`, SHA-256
     `4fe0963193125d7d95c396e2022cdf0fedff11437dfbbb641429bd71e936d103`.
 - Supported Python: 3.11 and newer; repository development version: 3.13
-- Documentation: [python-api.junjo.ai](https://python-api.junjo.ai/), verified
-  serving version `0.64.0`
+- Historical Sphinx documentation deployment:
+  [python-api.junjo.ai](https://python-api.junjo.ai/), verified serving version
+  `0.64.0` before the unified-documentation cutover
 
 The sole PyPI trusted publisher is:
 
@@ -173,7 +174,11 @@ The obsolete `publish.yml` publisher was removed.
 - Canonical source: `apps/website`
 - Production domain: [junjo.ai](https://junjo.ai/)
 - Restored-site commit: `d81fe0b3013310c7ec962c478c6790a0e487ba72`
-- Cloudflare Pages builds directly from `mdrideout/junjo` on `master`.
+- At the time of this consolidation record, Cloudflare Pages built directly
+  from `mdrideout/junjo` on `master`. The 2026-07-15 amendment to ADR 0009
+  supersedes that publishing path: GitHub Actions now owns the exact validated
+  direct-upload artifact, and Cloudflare automatic Git deployments are disabled
+  when the unified site is activated.
 
 The restored site preserves the original Starlight homepage and documentation
 content. The temporary migration redesign, gradients, replacement copy, and

--- a/docs/roadmaps/MONOREPO_MIGRATION_RECORD.md
+++ b/docs/roadmaps/MONOREPO_MIGRATION_RECORD.md
@@ -177,8 +177,8 @@ The obsolete `publish.yml` publisher was removed.
 - At the time of this consolidation record, Cloudflare Pages built directly
   from `mdrideout/junjo` on `master`. The 2026-07-15 amendment to ADR 0009
   supersedes that publishing path: GitHub Actions now owns the exact validated
-  direct-upload artifact, and Cloudflare automatic Git deployments are disabled
-  when the unified site is activated.
+  direct-upload artifact. Automatic production and preview deployments are
+  disabled on both Cloudflare Pages projects.
 
 The restored site preserves the original Starlight homepage and documentation
 content. The temporary migration redesign, gradients, replacement copy, and

--- a/docs/roadmaps/UNIFIED_DOCUMENTATION_MIGRATION.md
+++ b/docs/roadmaps/UNIFIED_DOCUMENTATION_MIGRATION.md
@@ -1,7 +1,7 @@
 # Unified Documentation Portal Migration Strategy And Implementation Plan
 
-- Status: Production cutover approved; deployment credentials and live
-  verification remain open
+- Status: Production source-build cutover approved; live verification remains
+  open
 - Date: 2026-07-15
 - Owners: Junjo platform, Python SDK, Studio, website, and future SDK owners
 - Decision authority: ADR 0009 accepts the unified publishing boundary; the
@@ -10,9 +10,10 @@
 ## Implementation Record
 
 The repository implementation began on `codex/unified-docs-migration`. On
-2026-07-15 the owner selected GitHub Actions direct upload for production and
-approved retirement of the legacy Sphinx site with a single global permanent
-redirect rather than page-by-page compatibility mappings.
+2026-07-15 the owner selected Cloudflare Pages Git builds gated by validated
+merges to protected `master` and approved retirement of the legacy Sphinx site
+with a single global permanent redirect rather than page-by-page compatibility
+mappings.
 
 Implemented:
 
@@ -26,16 +27,16 @@ Implemented:
 - a client-side compatibility map for legacy API fragments;
 - build validation for every migrated route, API route/anchor, baseline symbol,
   internal link, search artifact, sitemap, and unconverted markup token;
-- a path-routed GitHub Actions workflow that uploads the exact validated static
-  `next` artifact while retaining Sphinx as a parity gate;
+- a path-routed GitHub Actions workflow that validates the complete `next`
+  source assembly without persisting or deploying its generated output;
 - an explicit `next`/`stable` manifest and page label, with stable assembly
   callable only from a release-selected checkout;
-- a version-pinned Wrangler deployment job that publishes the retained site
-  artifact to `junjo-website`, then replaces the public Sphinx deployment on
-  `junjo-python-api` with a one-rule `301` redirect site; and
-- Cloudflare automatic production and preview deployments disabled on both
-  Pages projects without changing their current production deployments or
-  custom domains.
+- a version-controlled Cloudflare source-build command that repeats every
+  assembly and validation gate before publishing `apps/website/dist`;
+- a committed one-rule `301` redirect source plus a legacy-domain build gate
+  that waits for the unified Python landing page before retiring Sphinx; and
+- both Cloudflare Pages projects configured for automatic production builds
+  from `master`, with unvalidated branch previews disabled.
 
 The original audit contained 4,094 RST lines. Source work that landed during
 implementation expanded the live corpus to 4,113 lines and the Sphinx API
@@ -44,9 +45,8 @@ from the newer source; no content was frozen at the older counts.
 
 Still gated by production evidence:
 
-- configure the `public-documentation-production` GitHub environment with the
-  Cloudflare account ID and least-privilege Pages API token;
-- publish the validated artifact and global legacy-domain redirect; and
+- merge the green source and publish the unified build plus global
+  legacy-domain redirect; and
 - verify the unified routes, search, canonical metadata, and global redirect in
   production while retaining the final Sphinx artifact for rollback.
 
@@ -473,8 +473,10 @@ The Python exporter produces:
 - a redirects/legacy-anchor manifest; and
 - version and source-revision metadata.
 
-Generated files are build artifacts. They are written to an ignored staging
-directory or uploaded as versioned CI artifacts; they are not hand-edited.
+Generated files are build artifacts. The public documentation validator writes
+them only to ignored staging and build directories, then discards them when the
+job ends. SDK-owned release artifacts may use their own release storage, but
+this GitHub validator uploads nothing. Generated files are never hand-edited.
 
 ### API Parity Gates
 
@@ -538,10 +540,12 @@ commands and stages their output before the normal website build.
 
 ### Recommended Production Pipeline
 
-Use GitHub Actions to assemble and validate the exact static production
-artifact, then deploy that artifact to Cloudflare Pages. Do not let an opaque
-Cloudflare build independently regenerate API documentation from whatever main
-branch happens to contain.
+Use GitHub Actions to assemble and validate pull-request source without
+persisting its generated output. Required review and validation complete before
+the source reaches protected `master`. That merge is the production signal:
+Cloudflare Pages pulls the approved commit, runs the version-controlled root
+build contract, and deploys its own generated output. Cloudflare preview builds
+remain disabled so unapproved commits are never deployed.
 
 The production sequence is:
 
@@ -551,9 +555,10 @@ The production sequence is:
 4. build the static site;
 5. validate links, routes, anchors, symbol manifests, search, sitemap, and
    version metadata;
-6. retain the deployable artifact for rollback; and
-7. deploy documentation last, after the corresponding packages and Studio
-   release are public.
+6. merge the validated source to protected `master`;
+7. let Cloudflare independently repeat the complete build contract and deploy
+   only if it passes; and
+8. retire the Sphinx domain only after the unified Python landing page is live.
 
 For pull requests, a cross-component public-docs workflow builds `next` output
 from the changed source tree. It is triggered by:
@@ -741,14 +746,15 @@ Exit gate:
 - no generated or copied content is hand-edited in the portal; and
 - standalone deployment distributions remain complete.
 
-### Work Package 6: Release Integration And Production Direct Upload
+### Work Package 6: Release Integration And Cloudflare Source Build
 
 Tasks:
 
 - produce versioned docs artifacts with SDK releases;
 - assemble stable production docs from released artifacts;
 - publish an optional clearly labeled `next` preview;
-- deploy the exact GitHub Actions artifact to the unified site;
+- validate pull-request source in GitHub without persisting generated output;
+- merge approved source and let Cloudflare pull, build, and deploy it;
 - run production route, search, sitemap, canonical, and version checks; and
 - retain the prior website and final Sphinx artifacts as rollback inputs.
 

--- a/docs/roadmaps/UNIFIED_DOCUMENTATION_MIGRATION.md
+++ b/docs/roadmaps/UNIFIED_DOCUMENTATION_MIGRATION.md
@@ -25,26 +25,27 @@ Implemented:
 - source-owned Python and Studio content assembly without shared runtime locks;
 - a client-side compatibility map for legacy API fragments;
 - build validation for every migrated route, API route/anchor, baseline symbol,
-  internal link, search artifact, sitemap, and unconverted markup token; and
+  internal link, search artifact, sitemap, and unconverted markup token;
 - a path-routed GitHub Actions workflow that uploads the exact validated static
   `next` artifact while retaining Sphinx as a parity gate;
 - an explicit `next`/`stable` manifest and page label, with stable assembly
-  callable only from a release-selected checkout; and
-- a version-pinned Wrangler deployment job that publishes the retained site artifact
-  to `junjo-website`, then replaces the public Sphinx deployment on
-  `junjo-python-api` with a one-rule `301` redirect site.
+  callable only from a release-selected checkout;
+- a version-pinned Wrangler deployment job that publishes the retained site
+  artifact to `junjo-website`, then replaces the public Sphinx deployment on
+  `junjo-python-api` with a one-rule `301` redirect site; and
+- Cloudflare automatic production and preview deployments disabled on both
+  Pages projects without changing their current production deployments or
+  custom domains.
 
 The original audit contained 4,094 RST lines. Source work that landed during
 implementation expanded the live corpus to 4,113 lines and the Sphinx API
-inventory from 418 to 424 objects. The converter and baseline were refreshed
+inventory from 418 to 428 objects. The converter and baseline were refreshed
 from the newer source; no content was frozen at the older counts.
 
 Still gated by production evidence:
 
 - configure the `public-documentation-production` GitHub environment with the
   Cloudflare account ID and least-privilege Pages API token;
-- disable Cloudflare automatic Git deployments so GitHub Actions is the sole
-  production writer;
 - publish the validated artifact and global legacy-domain redirect; and
 - verify the unified routes, search, canonical metadata, and global redirect in
   production while retaining the final Sphinx artifact for rollback.

--- a/docs/roadmaps/UNIFIED_DOCUMENTATION_MIGRATION.md
+++ b/docs/roadmaps/UNIFIED_DOCUMENTATION_MIGRATION.md
@@ -1,17 +1,18 @@
 # Unified Documentation Portal Migration Strategy And Implementation Plan
 
-- Status: Cutover-ready implementation; production parallel-run and retirement
-  gates remain open
-- Date: 2026-07-14
+- Status: Production cutover approved; deployment credentials and live
+  verification remain open
+- Date: 2026-07-15
 - Owners: Junjo platform, Python SDK, Studio, website, and future SDK owners
 - Decision authority: ADR 0009 accepts the unified publishing boundary; the
   production and Sphinx-retirement gates in this document remain authoritative
 
 ## Implementation Record
 
-The repository implementation was created on
-`codex/unified-docs-migration`. It deliberately stops before production DNS,
-Cloudflare, or legacy-domain cutover.
+The repository implementation began on `codex/unified-docs-migration`. On
+2026-07-15 the owner selected GitHub Actions direct upload for production and
+approved retirement of the legacy Sphinx site with a single global permanent
+redirect rather than page-by-page compatibility mappings.
 
 Implemented:
 
@@ -26,9 +27,12 @@ Implemented:
 - build validation for every migrated route, API route/anchor, baseline symbol,
   internal link, search artifact, sitemap, and unconverted markup token; and
 - a path-routed GitHub Actions workflow that uploads the exact validated static
-  `next` artifact while retaining Sphinx as a parity gate; and
+  `next` artifact while retaining Sphinx as a parity gate;
 - an explicit `next`/`stable` manifest and page label, with stable assembly
-  callable only from a release-selected checkout.
+  callable only from a release-selected checkout; and
+- a version-pinned Wrangler deployment job that publishes the retained site artifact
+  to `junjo-website`, then replaces the public Sphinx deployment on
+  `junjo-python-api` with a one-rule `301` redirect site.
 
 The original audit contained 4,094 RST lines. Source work that landed during
 implementation expanded the live corpus to 4,113 lines and the Sphinx API
@@ -37,11 +41,13 @@ from the newer source; no content was frozen at the older counts.
 
 Still gated by production evidence:
 
-- publish the validated artifact to the production preview/parallel surface;
-- configure and exercise the `python-api.junjo.ai` compatibility redirects;
-- monitor production routes, search, fragments, canonical metadata, and 404s
-  for the agreed window; and
-- retire Sphinx only after those observations and rollback checks pass.
+- configure the `public-documentation-production` GitHub environment with the
+  Cloudflare account ID and least-privilege Pages API token;
+- disable Cloudflare automatic Git deployments so GitHub Actions is the sole
+  production writer;
+- publish the validated artifact and global legacy-domain redirect; and
+- verify the unified routes, search, canonical metadata, and global redirect in
+  production while retaining the final Sphinx artifact for rollback.
 
 ## Objective
 
@@ -586,33 +592,25 @@ making unrelated release builds nondeterministic.
 
 ## Legacy URL And Anchor Preservation
 
-Before moving pages, crawl and record all existing production Sphinx routes,
-including `.html`, extensionless Cloudflare variants, named document anchors,
-and API symbol fragments.
+The migration inventory records all existing production Sphinx routes,
+extensionless variants, named anchors, and API symbol fragments. Those records
+remain required evidence that the destination corpus contains the migrated
+content.
 
-The redirect manifest maps at least:
+For production retirement, the owner explicitly selected a global redirect
+instead of page-by-page routing. The separately deployed legacy site contains
+exactly this Cloudflare Pages rule:
 
 ```text
-https://python-api.junjo.ai/getting_started.html
-https://python-api.junjo.ai/getting_started
-https://python-api.junjo.ai/api.html
-https://python-api.junjo.ai/api
-https://python-api.junjo.ai/api.html#junjo.Workflow
+/* https://junjo.ai/docs/python/ 301
 ```
 
-to their new routes or compatibility pages.
-
-HTTP redirect handlers do not receive URL fragments. Therefore old Sphinx API
-anchors cannot be preserved by server redirects alone when the target symbol
-slug changes. Use one or both of:
-
-- legacy anchor aliases embedded in compatibility pages; and
-- a small, tested client-side fragment mapper on the legacy API landing route.
-
-Keep `python-api.junjo.ai` as a redirecting compatibility domain through at
-least the agreed support window. Do not merely turn off the Sphinx deployment.
-Monitor production 404s and unresolved legacy fragments during the parallel
-and post-cutover periods.
+Consequently, every request to `python-api.junjo.ai` enters the unified Python
+documentation landing page. Old path-specific and fragment-specific deep links
+are intentionally retired; URL fragments are not available to an HTTP redirect
+handler. The content and symbol routes remain directly available on
+`junjo.ai`, and the committed route and API manifests remain migration evidence
+rather than production redirect inputs.
 
 ## Implementation Work Packages
 
@@ -742,22 +740,21 @@ Exit gate:
 - no generated or copied content is hand-edited in the portal; and
 - standalone deployment distributions remain complete.
 
-### Work Package 6: Release Integration And Parallel Production
+### Work Package 6: Release Integration And Production Direct Upload
 
 Tasks:
 
 - produce versioned docs artifacts with SDK releases;
 - assemble stable production docs from released artifacts;
 - publish an optional clearly labeled `next` preview;
-- deploy the unified site without changing the old Sphinx domain;
-- run production route, fragment, search, sitemap, canonical, and version
-  checks; and
-- observe both sites through an agreed parallel validation window.
+- deploy the exact GitHub Actions artifact to the unified site;
+- run production route, search, sitemap, canonical, and version checks; and
+- retain the prior website and final Sphinx artifacts as rollback inputs.
 
 Exit gate:
 
 - the unified site describes installable released components;
-- every legacy route resolves correctly;
+- every unified route resolves correctly;
 - production monitoring shows no unexplained content or link regressions; and
 - the retained static artifact can be redeployed as a rollback.
 
@@ -765,7 +762,8 @@ Exit gate:
 
 Tasks:
 
-- redirect `python-api.junjo.ai` through the tested compatibility mapping;
+- redirect every `python-api.junjo.ai` request permanently to the unified
+  Python documentation landing page;
 - update PyPI metadata, repository READMEs, website links, sitemaps, and
   canonical URLs;
 - retain the final Sphinx artifact for rollback and historical comparison;
@@ -776,11 +774,11 @@ Tasks:
 
 Exit gate:
 
-- the support window completes without unresolved regressions;
+- the unified site and global redirect pass live production verification;
 - no source or content-ledger record remains pending;
 - there is no second manually maintained API reference; and
-- the old Sphinx deployment can be retired without losing a public route,
-  symbol, or useful document.
+- the old Sphinx deployment is retired without losing migrated content, while
+  its page-specific public URLs are recorded as intentionally retired.
 
 ### Work Package 8: Future TypeScript SDK Integration
 
@@ -820,10 +818,11 @@ away the already migrated Python content.
 ## Rollback Strategy
 
 Every production documentation deployment retains its complete static artifact
-and input manifests. During parallel publication:
+and input manifests. During cutover:
 
-- the existing Sphinx site remains deployable;
-- DNS and compatibility redirects remain independently reversible;
+- the final Sphinx site remains available as a retained rollback artifact;
+- the legacy Pages project can be restored from the final Sphinx artifact,
+  although clients may cache the approved permanent redirect;
 - the unified site can roll back to its previous static artifact without
   rebuilding SDK docs;
 - generated documentation artifacts remain immutable; and
@@ -870,14 +869,15 @@ The migration is complete only when all of the following are true:
   revision;
 - Starlight search, sitemap, internal links, canonical URLs, and accessibility
   validation pass;
-- all legacy pages and API deep links resolve through preserved anchors or
-  tested compatibility mappings;
+- the global legacy-domain redirect resolves to the unified Python landing page
+  and page-specific legacy URLs are recorded as intentionally retired;
 - deployment distributions remain self-contained;
-- production has completed the agreed parallel validation and rollback window;
+- production has passed unified-site and redirect verification;
 - the Python release policy and CI use the new documentation export contract;
 - no hand-maintained duplicate API reference exists; and
 - the final migration record lists every correction and intentionally retired
   placeholder or Sphinx-only feature.
 
 Until every criterion passes, the work remains a migration in progress and the
-Sphinx sources and rollback artifact remain authoritative recovery inputs.
+Sphinx sources and rollback artifact remain authoritative recovery inputs, not
+a second public documentation site.

--- a/tooling/docs/README.md
+++ b/tooling/docs/README.md
@@ -59,9 +59,9 @@ with the global `301` redirect.
 
 The GitHub `public-documentation-production` environment owns
 `CLOUDFLARE_ACCOUNT_ID` and `CLOUDFLARE_API_TOKEN`. The token needs only
-Cloudflare Pages edit access for the owning account. Cloudflare's automatic Git
-deployments must be disabled when this pipeline is activated so a second build
-cannot overwrite the validated artifact.
+Cloudflare Pages edit access for the owning account. Automatic Git deployments
+are disabled on both Pages projects, so a second builder cannot overwrite the
+validated artifact.
 
 ## Language SDK artifact contract
 

--- a/tooling/docs/README.md
+++ b/tooling/docs/README.md
@@ -17,10 +17,10 @@ product documentation.
 4. Astro/Starlight builds one immutable deployable. The post-build validator
    checks all routes, anchors, links, search output, sitemap output, migration
    entries, and Sphinx API objects.
-5. Assembly emits `.docs-assembly/python-api._redirects`, a reversible
-   Cloudflare Pages compatibility artifact for the legacy domain. Never deploy
-   that file on `junjo.ai`; deploy it on `python-api.junjo.ai` only after the
-   roadmap's parallel validation gate.
+5. Assembly emits `.docs-assembly/python-api-site`, a separately deployable
+   Cloudflare Pages retirement artifact. Its single permanent rule redirects
+   every `python-api.junjo.ai` request to `https://junjo.ai/docs/python/`.
+   Never include this artifact in the `junjo.ai` deployment.
 
 Run the converter in its isolated dependency environment:
 
@@ -47,6 +47,21 @@ The default channel is `next`. A release workflow can set
 source revision. The channel is visible on API pages and recorded in both
 manifests, so an unreleased source preview cannot silently masquerade as stable
 documentation.
+
+## Cloudflare deployment
+
+The `Public Documentation` workflow is the only production build pipeline. It
+assembles, validates, and uploads `apps/website/dist`, then a separate deploy
+job downloads that exact artifact and publishes it to the `junjo-website`
+Cloudflare Pages project. Only after that succeeds does it deploy
+`.docs-assembly/python-api-site` to `junjo-python-api`, retiring the Sphinx site
+with the global `301` redirect.
+
+The GitHub `public-documentation-production` environment owns
+`CLOUDFLARE_ACCOUNT_ID` and `CLOUDFLARE_API_TOKEN`. The token needs only
+Cloudflare Pages edit access for the owning account. Cloudflare's automatic Git
+deployments must be disabled when this pipeline is activated so a second build
+cannot overwrite the validated artifact.
 
 ## Language SDK artifact contract
 

--- a/tooling/docs/README.md
+++ b/tooling/docs/README.md
@@ -17,10 +17,10 @@ product documentation.
 4. Astro/Starlight builds one immutable deployable. The post-build validator
    checks all routes, anchors, links, search output, sitemap output, migration
    entries, and Sphinx API objects.
-5. Assembly emits `.docs-assembly/python-api-site`, a separately deployable
-   Cloudflare Pages retirement artifact. Its single permanent rule redirects
-   every `python-api.junjo.ai` request to `https://junjo.ai/docs/python/`.
-   Never include this artifact in the `junjo.ai` deployment.
+5. Assembly copies and validates `apps/website/legacy-python-api`, the
+   separately deployed Cloudflare Pages source for the retired domain. Its
+   single permanent rule redirects every `python-api.junjo.ai` request to
+   `https://junjo.ai/docs/python/`. Never include it in the `junjo.ai` output.
 
 Run the converter in its isolated dependency environment:
 
@@ -50,18 +50,29 @@ documentation.
 
 ## Cloudflare deployment
 
-The `Public Documentation` workflow is the only production build pipeline. It
-assembles, validates, and uploads `apps/website/dist`, then a separate deploy
-job downloads that exact artifact and publishes it to the `junjo-website`
-Cloudflare Pages project. Only after that succeeds does it deploy
-`.docs-assembly/python-api-site` to `junjo-python-api`, retiring the Sphinx site
-with the global `301` redirect.
+Cloudflare Pages owns production builds through its Git integration. The
+`junjo-website` project runs this version-controlled command from the repository
+root:
 
-The GitHub `public-documentation-production` environment owns
-`CLOUDFLARE_ACCOUNT_ID` and `CLOUDFLARE_API_TOKEN`. The token needs only
-Cloudflare Pages edit access for the owning account. Automatic Git deployments
-are disabled on both Pages projects, so a second builder cannot overwrite the
-validated artifact.
+```bash
+bash tooling/docs/build_cloudflare_pages.sh
+```
+
+The build output is `apps/website/dist`. The script installs a pinned `uv`,
+builds and validates the Sphinx parity source, validates the narrative ledger,
+assembles the source-owned exports, runs all Starlight checks, and audits
+production dependencies. GitHub Actions independently runs the same gates as a
+pull-request validator, but does not upload, retain, or deploy its generated
+output. Merging the validated source to protected `master` is the production
+signal; Cloudflare then pulls, builds, and deploys that commit. Automatic
+production builds are enabled for `master`, while Cloudflare branch previews
+are disabled so unvalidated source is never deployed.
+
+The `junjo-python-api` project runs
+`tooling/docs/build_legacy_python_redirect.sh`, which waits for the unified
+Python landing page before publishing the committed
+`apps/website/legacy-python-api` directory. That directory contains only the
+global `301` rule. Neither Pages project consumes a checked-in `dist` directory.
 
 ## Language SDK artifact contract
 

--- a/tooling/docs/assemble_public_docs.py
+++ b/tooling/docs/assemble_public_docs.py
@@ -19,9 +19,10 @@ CONTENT_OUTPUT = WEBSITE_ROOT / "src/content/docs/generated"
 ASSET_OUTPUT = WEBSITE_ROOT / "public/docs-assets/generated/python"
 MANIFEST_OUTPUT = WEBSITE_ROOT / "public/docs-manifests/generated/python"
 ASSEMBLY_RECORD = WEBSITE_ROOT / ".docs-assembly/manifest.json"
-LEGACY_REDIRECT_OUTPUT = WEBSITE_ROOT / ".docs-assembly/python-api._redirects"
+LEGACY_SITE_OUTPUT = WEBSITE_ROOT / ".docs-assembly/python-api-site"
 PYTHON_ROOT = REPOSITORY_ROOT / "sdks/python"
 DOCUMENTATION_CHANNEL = os.environ.get("JUNJO_DOCS_CHANNEL", "next")
+LEGACY_REDIRECT_TARGET = "https://junjo.ai/docs/python/"
 
 
 def sha256_file(path: Path) -> str:
@@ -83,29 +84,26 @@ def build_assembly(root: Path) -> None:
         REPOSITORY_ROOT / "sdks/python/docs/api-sphinx-baseline.json",
         manifests / "sphinx-api-baseline.json",
     )
-    shutil.copy2(REPOSITORY_ROOT / "tooling/docs/content-migration.json", manifests / "content-migration.json")
-    shutil.copy2(REPOSITORY_ROOT / "tooling/docs/legacy-routes.json", manifests / "legacy-routes.json")
+    shutil.copy2(
+        REPOSITORY_ROOT / "tooling/docs/content-migration.json",
+        manifests / "content-migration.json",
+    )
+    shutil.copy2(
+        REPOSITORY_ROOT / "tooling/docs/legacy-routes.json",
+        manifests / "legacy-routes.json",
+    )
 
-    legacy_routes = json.loads((manifests / "legacy-routes.json").read_text(encoding="utf-8"))
-    redirect_targets: dict[str, str] = {}
-    for entry in legacy_routes["routes"]:
-        target = (
-            "https://junjo.ai/api"
-            if entry["source_document"] == "api.rst"
-            else f"https://junjo.ai{entry['target_route']}"
-        )
-        for source_route in entry["source_routes"]:
-            previous = redirect_targets.setdefault(source_route, target)
-            if previous != target:
-                raise ValueError(f"legacy route {source_route} has conflicting targets")
-    redirects = [
-        "# Deploy only on python-api.junjo.ai after the parallel validation gate.",
-        "# Temporary redirects keep rollback reversible; promote to 301 only at retirement.",
-        *(f"{source} {target} 302" for source, target in sorted(redirect_targets.items())),
-    ]
-    (root / "python-api._redirects").write_text("\n".join(redirects) + "\n", encoding="utf-8")
+    legacy_site = root / "python-api-site"
+    legacy_site.mkdir(parents=True)
+    (legacy_site / "_redirects").write_text(
+        "# The Python Sphinx site is retired. All legacy requests enter the unified docs here.\n"
+        f"/* {LEGACY_REDIRECT_TARGET} 301\n",
+        encoding="utf-8",
+    )
 
-    api_manifest = json.loads((manifests / "api-manifest.json").read_text(encoding="utf-8"))
+    api_manifest = json.loads(
+        (manifests / "api-manifest.json").read_text(encoding="utf-8")
+    )
     legacy_api_map: dict[str, str] = {}
     for symbol in api_manifest["symbols"]:
         anchor = symbol["legacy_anchor"]
@@ -121,7 +119,11 @@ def build_assembly(root: Path) -> None:
     )
 
     files: list[dict[str, str]] = []
-    for category, directory in (("content", content), ("asset", assets), ("manifest", manifests)):
+    for category, directory in (
+        ("content", content),
+        ("asset", assets),
+        ("manifest", manifests),
+    ):
         for path in sorted(directory.rglob("*")):
             if path.is_file():
                 files.append(
@@ -134,8 +136,8 @@ def build_assembly(root: Path) -> None:
     files.append(
         {
             "category": "compatibility",
-            "path": "python-api._redirects",
-            "hash": sha256_file(root / "python-api._redirects"),
+            "path": "python-api-site/_redirects",
+            "hash": sha256_file(root / "python-api-site/_redirects"),
         }
     )
     record = {
@@ -161,13 +163,17 @@ def write_assembly(temporary: Path) -> None:
     replace_output(temporary / "manifests", MANIFEST_OUTPUT)
     ASSEMBLY_RECORD.parent.mkdir(parents=True, exist_ok=True)
     shutil.copy2(temporary / "assembly-manifest.json", ASSEMBLY_RECORD)
-    shutil.copy2(temporary / "python-api._redirects", LEGACY_REDIRECT_OUTPUT)
+    replace_output(temporary / "python-api-site", LEGACY_SITE_OUTPUT)
 
 
 def directory_files(root: Path) -> dict[Path, bytes]:
     if not root.exists():
         return {}
-    return {path.relative_to(root): path.read_bytes() for path in root.rglob("*") if path.is_file()}
+    return {
+        path.relative_to(root): path.read_bytes()
+        for path in root.rglob("*")
+        if path.is_file()
+    }
 
 
 def compare_directory(expected: Path, actual: Path, label: str) -> list[str]:
@@ -177,7 +183,9 @@ def compare_directory(expected: Path, actual: Path, label: str) -> list[str]:
     missing = sorted(expected_files.keys() - actual_files.keys())
     extra = sorted(actual_files.keys() - expected_files.keys())
     stale = sorted(
-        path for path in expected_files.keys() & actual_files.keys() if expected_files[path] != actual_files[path]
+        path
+        for path in expected_files.keys() & actual_files.keys()
+        if expected_files[path] != actual_files[path]
     )
     failures.extend(f"{label}: missing {path}" for path in missing)
     failures.extend(f"{label}: unexpected {path}" for path in extra)
@@ -196,11 +204,13 @@ def check_assembly(temporary: Path) -> int:
         failures.append("assembly record is missing")
     elif ASSEMBLY_RECORD.read_bytes() != expected_record:
         failures.append("assembly record is stale")
-    expected_redirects = (temporary / "python-api._redirects").read_bytes()
-    if not LEGACY_REDIRECT_OUTPUT.exists():
-        failures.append("legacy-domain redirect artifact is missing")
-    elif LEGACY_REDIRECT_OUTPUT.read_bytes() != expected_redirects:
-        failures.append("legacy-domain redirect artifact is stale")
+    failures.extend(
+        compare_directory(
+            temporary / "python-api-site",
+            LEGACY_SITE_OUTPUT,
+            "legacy-domain redirect site",
+        )
+    )
     if failures:
         print("\n".join(failures), file=sys.stderr)
         return 1
@@ -223,8 +233,12 @@ def main() -> int:
         build_assembly(temporary)
         if args.write:
             write_assembly(temporary)
-            record = json.loads((temporary / "assembly-manifest.json").read_text(encoding="utf-8"))
-            print(f"Assembled {len(record['files'])} documentation files into Starlight staging.")
+            record = json.loads(
+                (temporary / "assembly-manifest.json").read_text(encoding="utf-8")
+            )
+            print(
+                f"Assembled {len(record['files'])} documentation files into Starlight staging."
+            )
             return 0
         return check_assembly(temporary)
 

--- a/tooling/docs/assemble_public_docs.py
+++ b/tooling/docs/assemble_public_docs.py
@@ -20,9 +20,9 @@ ASSET_OUTPUT = WEBSITE_ROOT / "public/docs-assets/generated/python"
 MANIFEST_OUTPUT = WEBSITE_ROOT / "public/docs-manifests/generated/python"
 ASSEMBLY_RECORD = WEBSITE_ROOT / ".docs-assembly/manifest.json"
 LEGACY_SITE_OUTPUT = WEBSITE_ROOT / ".docs-assembly/python-api-site"
+LEGACY_SITE_SOURCE = WEBSITE_ROOT / "legacy-python-api"
 PYTHON_ROOT = REPOSITORY_ROOT / "sdks/python"
 DOCUMENTATION_CHANNEL = os.environ.get("JUNJO_DOCS_CHANNEL", "next")
-LEGACY_REDIRECT_TARGET = "https://junjo.ai/docs/python/"
 
 
 def sha256_file(path: Path) -> str:
@@ -93,13 +93,7 @@ def build_assembly(root: Path) -> None:
         manifests / "legacy-routes.json",
     )
 
-    legacy_site = root / "python-api-site"
-    legacy_site.mkdir(parents=True)
-    (legacy_site / "_redirects").write_text(
-        "# The Python Sphinx site is retired. All legacy requests enter the unified docs here.\n"
-        f"/* {LEGACY_REDIRECT_TARGET} 301\n",
-        encoding="utf-8",
-    )
+    copy_tree_without_overwrite(LEGACY_SITE_SOURCE, root / "python-api-site")
 
     api_manifest = json.loads(
         (manifests / "api-manifest.json").read_text(encoding="utf-8")

--- a/tooling/docs/build_cloudflare_pages.sh
+++ b/tooling/docs/build_cloudflare_pages.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repository_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$repository_root"
+
+required_uv_version="0.11.7"
+if ! command -v uv >/dev/null 2>&1 || \
+  [[ "$(uv --version)" != "uv ${required_uv_version} "* ]]; then
+  python3 -m pip install --disable-pip-version-check "uv==${required_uv_version}"
+fi
+
+(
+  cd sdks/python
+  uv sync --frozen --package junjo --extra dev
+  uv run sphinx-build -W -b html docs docs/_build/html
+  uv run python docs/export_api.py baseline-check \
+    --inventory docs/_build/html/objects.inv
+)
+
+(
+  cd tooling/docs
+  uv sync --frozen
+  uv run python migrate_rst.py --check
+)
+
+(
+  cd apps/website
+  npm ci
+  npm run docs:assemble
+  npm run check
+  npm run build
+  npm run validate:build
+  npm run docs:check
+  npm audit --omit=dev --audit-level=high
+)

--- a/tooling/docs/build_legacy_python_redirect.sh
+++ b/tooling/docs/build_legacy_python_redirect.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Do not retire the Sphinx site until the unified Python landing page is live.
+unified_docs_url="${JUNJO_UNIFIED_PYTHON_DOCS_URL:-https://junjo.ai/docs/python/}"
+curl \
+  --fail \
+  --silent \
+  --show-error \
+  --output /dev/null \
+  --retry 40 \
+  --retry-all-errors \
+  --retry-delay 15 \
+  --max-time 10 \
+  "$unified_docs_url"

--- a/tooling/scripts/validate_repository.py
+++ b/tooling/scripts/validate_repository.py
@@ -365,6 +365,28 @@ def validate_website_build_contract() -> None:
         "npm run validate:build" in website_ci,
         "website CI must validate generated internal links and source references",
     )
+    required_deployment_contract = (
+        "name: public-documentation-${{ env.JUNJO_DOCS_CHANNEL }}-${{ github.sha }}",
+        "name: public-documentation-next-${{ github.sha }}",
+        "name: python-api-retirement-${{ github.sha }}",
+        "npx --yes wrangler@4.111.0 pages deploy",
+        "--project-name=junjo-website",
+        "--project-name=junjo-python-api",
+        "CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}",
+        "CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}",
+    )
+    require(
+        all(fragment in website_ci for fragment in required_deployment_contract),
+        "website CI must direct-upload the exact retained site and retirement artifacts",
+    )
+    assembler = (PLATFORM_ROOT / "tooling/docs/assemble_public_docs.py").read_text(
+        encoding="utf-8"
+    )
+    require(
+        'LEGACY_REDIRECT_TARGET = "https://junjo.ai/docs/python/"' in assembler
+        and 'f"/* {LEGACY_REDIRECT_TARGET} 301\\n"' in assembler,
+        "the retired Python API domain must use one permanent global redirect",
+    )
     validator = (PLATFORM_ROOT / "apps/website/scripts/validate-build.mjs").read_text(
         encoding="utf-8"
     )

--- a/tooling/scripts/validate_repository.py
+++ b/tooling/scripts/validate_repository.py
@@ -365,27 +365,61 @@ def validate_website_build_contract() -> None:
         "npm run validate:build" in website_ci,
         "website CI must validate generated internal links and source references",
     )
-    required_deployment_contract = (
-        "name: public-documentation-${{ env.JUNJO_DOCS_CHANNEL }}-${{ github.sha }}",
-        "name: public-documentation-next-${{ github.sha }}",
-        "name: python-api-retirement-${{ github.sha }}",
-        "npx --yes wrangler@4.111.0 pages deploy",
-        "--project-name=junjo-website",
-        "--project-name=junjo-python-api",
-        "CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}",
-        "CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}",
+    require(
+        "wrangler" not in website_ci and "CLOUDFLARE_API_TOKEN" not in website_ci,
+        "website CI validates source but Cloudflare Pages owns production builds",
     )
     require(
-        all(fragment in website_ci for fragment in required_deployment_contract),
-        "website CI must direct-upload the exact retained site and retirement artifacts",
-    )
-    assembler = (PLATFORM_ROOT / "tooling/docs/assemble_public_docs.py").read_text(
-        encoding="utf-8"
+        "upload-artifact" not in website_ci,
+        "website CI must not persist or deploy a documentation artifact",
     )
     require(
-        'LEGACY_REDIRECT_TARGET = "https://junjo.ai/docs/python/"' in assembler
-        and 'f"/* {LEGACY_REDIRECT_TARGET} 301\\n"' in assembler,
+        "name: Public Documentation Validation" in website_ci
+        and "name: Public documentation" in website_ci
+        and "docs_changed: ${{ steps.scope.outputs.docs_changed }}" in website_ci,
+        "website CI must expose an always-present, path-scoped validation gate",
+    )
+    cloudflare_build = (
+        PLATFORM_ROOT / "tooling/docs/build_cloudflare_pages.sh"
+    ).read_text(encoding="utf-8")
+    required_cloudflare_build_contract = (
+        'required_uv_version="0.11.7"',
+        'python3 -m pip install --disable-pip-version-check "uv==${required_uv_version}"',
+        "uv run sphinx-build -W -b html docs docs/_build/html",
+        "uv run python migrate_rst.py --check",
+        "npm ci",
+        "npm run docs:assemble",
+        "npm run check",
+        "npm run build",
+        "npm run validate:build",
+        "npm run docs:check",
+        "npm audit --omit=dev --audit-level=high",
+    )
+    require(
+        all(
+            fragment in cloudflare_build
+            for fragment in required_cloudflare_build_contract
+        ),
+        "the Cloudflare source build must run every public documentation gate",
+    )
+    legacy_redirect = (
+        PLATFORM_ROOT / "apps/website/legacy-python-api/_redirects"
+    ).read_text(encoding="utf-8")
+    require(
+        legacy_redirect.splitlines()
+        == [
+            "# The Python Sphinx site is retired. All legacy requests enter the unified docs here.",
+            "/* https://junjo.ai/docs/python/ 301",
+        ],
         "the retired Python API domain must use one permanent global redirect",
+    )
+    legacy_build = (
+        PLATFORM_ROOT / "tooling/docs/build_legacy_python_redirect.sh"
+    ).read_text(encoding="utf-8")
+    require(
+        "https://junjo.ai/docs/python/" in legacy_build
+        and "--retry-all-errors" in legacy_build,
+        "the legacy-domain build must wait for the unified Python landing page",
     )
     validator = (PLATFORM_ROOT / "apps/website/scripts/validate-build.mjs").read_text(
         encoding="utf-8"


### PR DESCRIPTION
## Summary

- make GitHub Actions a validation-only gate: no documentation artifact upload, retention, deployment job, Cloudflare token, or production environment
- require the always-present `Public documentation` check before protected `master` can advance
- let Cloudflare Pages pull the validated `master` commit, repeat the version-controlled source build, and deploy its own generated `apps/website/dist`
- disable Cloudflare branch previews so unvalidated commits are never deployed
- replace the public Sphinx project with a committed one-rule global redirect source after the unified Python landing page is live
- preserve all migrated content, route ledgers, Sphinx source, and the final Sphinx deployment as rollback evidence

## Cloudflare production configuration

`junjo-website`:

- branch: `master`
- build: `bash tooling/docs/build_cloudflare_pages.sh`
- output: `apps/website/dist`
- production builds: enabled
- preview builds: disabled

`junjo-python-api`:

- branch: `master`
- build: `bash tooling/docs/build_legacy_python_redirect.sh`
- output: `apps/website/legacy-python-api`
- production builds: enabled
- preview builds: disabled

## Validation

- exact Cloudflare source-build command passed locally
- warning-strict Sphinx build and 428-object baseline validation
- narrative migration ledger check
- Astro/Starlight check, 132-page build, Pagefind, sitemap, internal-link and parity validation
- deterministic documentation assembly check
- global redirect source parsed and exercised locally
- legacy retirement build verified to wait for the unified Python landing page
- repository invariants and 107 tooling tests
- Actionlint and Zizmor
- production dependency audit (0 vulnerabilities)
