### PR TITLE
Fix Cloudflare Pages uv bootstrap

### DIFF
--- a/tooling/docs/build_cloudflare_pages.sh
+++ b/tooling/docs/build_cloudflare_pages.sh
@@ -8,6 +8,15 @@ required_uv_version="0.11.7"
 if ! command -v uv >/dev/null 2>&1 || \
   [[ "$(uv --version)" != "uv ${required_uv_version} "* ]]; then
   python3 -m pip install --disable-pip-version-check "uv==${required_uv_version}"
+
+  uv() {
+    python3 -m uv "$@"
+  }
+fi
+
+if [[ "$(uv --version)" != "uv ${required_uv_version} "* ]]; then
+  echo "Required uv ${required_uv_version} is unavailable" >&2
+  exit 1
 fi
 
 (


### PR DESCRIPTION
## Summary

- invoke the pinned uv wheel through Python when Cloudflare installs it outside PATH
- fail explicitly if the required uv version is still unavailable
- preserve the validator-only GitHub / source-building Cloudflare architecture

## Validation

- exact Cloudflare build contract in a clean venv with uv absent from PATH
- repository invariant validator
- documentation migration tests
- bash syntax and diff checks

## Production context

The first protected-master source build cloned the correct merge SHA but failed because Cloudflare's pip-installed console scripts directory was not on PATH. This fixes only that environment bootstrap issue; GitHub still stores and deploys no documentation artifact.