### PR TITLE
Record unified docs production cutover

### DIFF
--- a/docs/roadmaps/MONOREPO_MIGRATION_RECORD.md
+++ b/docs/roadmaps/MONOREPO_MIGRATION_RECORD.md
@@ -180,6 +180,12 @@ The obsolete `publish.yml` publisher was removed.
   Actions validates pull-request source without retaining an artifact, and
   Cloudflare pulls validated `master`, repeats the version-controlled build,
   and deploys its own output. Cloudflare preview builds are disabled.
+- The unified-documentation cutover completed from protected `master` commit
+  `f2a19f1b9ef00a5c3935e83b37b1f8f8ffe81ab0`. Cloudflare source-built website
+  deployment `8fec9dd8-20cb-4acb-8801-b89de9dd35da` serves the unified portal,
+  and source-built legacy deployment `92eee7cb-c1bb-47d9-ae20-db5f9aa09868`
+  globally redirects `python-api.junjo.ai` to
+  `https://junjo.ai/docs/python/`.
 
 The restored site preserves the original Starlight homepage and documentation
 content. The temporary migration redesign, gradients, replacement copy, and

--- a/docs/roadmaps/UNIFIED_DOCUMENTATION_MIGRATION.md
+++ b/docs/roadmaps/UNIFIED_DOCUMENTATION_MIGRATION.md
@@ -1,7 +1,7 @@
 # Unified Documentation Portal Migration Strategy And Implementation Plan
 
-- Status: Production source-build cutover approved; live verification remains
-  open
+- Status: Production source-build cutover complete; post-cutover release-policy
+  cleanup remains
 - Date: 2026-07-15
 - Owners: Junjo platform, Python SDK, Studio, website, and future SDK owners
 - Decision authority: ADR 0009 accepts the unified publishing boundary; the
@@ -43,12 +43,28 @@ implementation expanded the live corpus to 4,113 lines and the Sphinx API
 inventory from 418 to 428 objects. The converter and baseline were refreshed
 from the newer source; no content was frozen at the older counts.
 
-Still gated by production evidence:
+Production evidence completed on 2026-07-15:
 
-- merge the green source and publish the unified build plus global
-  legacy-domain redirect; and
-- verify the unified routes, search, canonical metadata, and global redirect in
-  production while retaining the final Sphinx artifact for rollback.
+- protected pull requests 22 and 23 passed the required Gitleaks, platform
+  integrity, and public-documentation checks before reaching `master`;
+- Cloudflare Pages pulled commit
+  `f2a19f1b9ef00a5c3935e83b37b1f8f8ffe81ab0`, built the unified portal as
+  deployment `8fec9dd8-20cb-4acb-8801-b89de9dd35da`, and assigned
+  `https://junjo.ai` only after the source build succeeded;
+- the homepage, docs hub, Python landing page, generated Python API index, and
+  a generated symbol page returned `200` from the production domain;
+- Cloudflare pulled the same commit for the retired Sphinx domain and published
+  redirect deployment `92eee7cb-c1bb-47d9-ae20-db5f9aa09868`; and
+- the legacy domain root, an old API page, an old generated page, and an
+  arbitrary deep path all returned `301` to
+  `https://junjo.ai/docs/python/`. The final Sphinx deployment remains in
+  Cloudflare history as a rollback input.
+
+The remaining work is post-cutover lifecycle cleanup: finish the
+release-selected stable-artifact policy, then remove Sphinx from active
+generation only when the Python release policy and CI use the replacement
+export contract. The Sphinx source and final artifact remain authoritative
+recovery inputs until those completion criteria pass.
 
 ## Objective
 


### PR DESCRIPTION
## Summary

- mark the unified documentation production cutover and legacy-domain retirement verified
- persist the exact protected master commit and Cloudflare source-build deployment IDs
- distinguish completed production migration from remaining release-policy cleanup

## Production evidence

- unified site deployment: `8fec9dd8-20cb-4acb-8801-b89de9dd35da`
- legacy redirect deployment: `92eee7cb-c1bb-47d9-ae20-db5f9aa09868`
- both pulled commit: `f2a19f1b9ef00a5c3935e83b37b1f8f8ffe81ab0`
- representative unified routes returned 200
- representative legacy root and deep routes returned global 301

## Validation

- exact Cloudflare source build contract
- repository invariants
- 132 generated website pages / 428 Python API objects / 140 assembled documentation files
- npm audit: zero vulnerabilities