### PR TITLE
Gate documentation production on published releases

### DIFF
--- a/.github/workflows/documentation-production-promotion.yml
+++ b/.github/workflows/documentation-production-promotion.yml
@@ -1,0 +1,34 @@
+name: Documentation Production Promotion
+
+on:
+  workflow_call:
+    inputs:
+      release_tag:
+        description: Published release tag whose exact commit becomes the production source
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  promote:
+    name: Promote published documentation source
+    runs-on: ubuntu-latest
+    concurrency:
+      group: documentation-production
+      cancel-in-progress: false
+    steps:
+      - name: Checkout release source and history
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          ref: ${{ inputs.release_tag }}
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Fast-forward the Cloudflare production source branch
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: >-
+          python3 tooling/docs/promote_production_branch.py
+          --repository "$GITHUB_REPOSITORY"
+          --release-tag "${{ inputs.release_tag }}"

--- a/.github/workflows/documentation-production-promotion.yml
+++ b/.github/workflows/documentation-production-promotion.yml
@@ -28,7 +28,8 @@ jobs:
       - name: Fast-forward the Cloudflare production source branch
         env:
           GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ inputs.release_tag }}
         run: >-
           python3 tooling/docs/promote_production_branch.py
           --repository "$GITHUB_REPOSITORY"
-          --release-tag "${{ inputs.release_tag }}"
+          --release-tag "$RELEASE_TAG"

--- a/.github/workflows/documentation-publish.yml
+++ b/.github/workflows/documentation-publish.yml
@@ -1,0 +1,29 @@
+name: Publish Documentation Release
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: documentation-release-${{ github.event.release.tag_name }}
+  cancel-in-progress: false
+
+jobs:
+  validation:
+    if: startsWith(github.event.release.tag_name, 'docs-release-')
+    uses: ./.github/workflows/website-ci.yml
+    with:
+      documentation_channel: stable
+      release_tag: ${{ github.event.release.tag_name }}
+
+  promote:
+    if: startsWith(github.event.release.tag_name, 'docs-release-')
+    needs: validation
+    permissions:
+      contents: write
+    uses: ./.github/workflows/documentation-production-promotion.yml
+    with:
+      release_tag: ${{ github.event.release.tag_name }}

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -24,6 +24,13 @@ jobs:
     if: startsWith(github.event.release.tag_name, 'sdk-python-v')
     uses: ./.github/workflows/ai-chat-compose-smoke.yml
 
+  documentation-validation:
+    if: startsWith(github.event.release.tag_name, 'sdk-python-v')
+    uses: ./.github/workflows/website-ci.yml
+    with:
+      documentation_channel: stable
+      release_tag: ${{ github.event.release.tag_name }}
+
   build-release:
     if: startsWith(github.event.release.tag_name, 'sdk-python-v')
     runs-on: ubuntu-latest
@@ -81,7 +88,12 @@ jobs:
 
   publish:
     if: startsWith(github.event.release.tag_name, 'sdk-python-v')
-    needs: [sdk-validation, examples-validation, compose-validation, build-release]
+    needs:
+      - sdk-validation
+      - examples-validation
+      - compose-validation
+      - documentation-validation
+      - build-release
     runs-on: ubuntu-latest
     environment:
       name: pypi
@@ -100,3 +112,12 @@ jobs:
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
         with:
           packages-dir: dist/
+
+  promote-documentation:
+    if: startsWith(github.event.release.tag_name, 'sdk-python-v')
+    needs: publish
+    permissions:
+      contents: write
+    uses: ./.github/workflows/documentation-production-promotion.yml
+    with:
+      release_tag: ${{ github.event.release.tag_name }}

--- a/.github/workflows/studio-docker-publish.yml
+++ b/.github/workflows/studio-docker-publish.yml
@@ -25,6 +25,14 @@ jobs:
     with:
       version: ${{ inputs.version }}
 
+  documentation_validation:
+    if: needs.validation.outputs.production == 'true'
+    needs: validation
+    uses: ./.github/workflows/website-ci.yml
+    with:
+      documentation_channel: stable
+      release_tag: ${{ github.ref_name }}
+
   dockerhub_controls:
     if: needs.validation.outputs.production == 'true'
     needs: validation
@@ -652,6 +660,7 @@ jobs:
     if: needs.validation.outputs.production == 'true'
     needs:
       - validation
+      - documentation_validation
       - exact_manifests
       - publish_distributions
       - promote_floating_tags
@@ -752,3 +761,14 @@ jobs:
             --verify-tag \
             --title "Junjo AI Studio ${VERSION}" \
             --notes-file /tmp/studio-release/RELEASE_NOTES.md
+
+  promote_documentation:
+    if: needs.validation.outputs.production == 'true'
+    needs:
+      - validation
+      - publish_release
+    permissions:
+      contents: write
+    uses: ./.github/workflows/documentation-production-promotion.yml
+    with:
+      release_tag: ${{ github.ref_name }}

--- a/.github/workflows/website-ci.yml
+++ b/.github/workflows/website-ci.yml
@@ -13,6 +13,7 @@ on:
       - "docs/roadmaps/**"
       - "tooling/docs/**"
       - ".github/workflows/website-ci.yml"
+      - ".github/workflows/documentation-*.yml"
   pull_request:
     branches: [master]
   workflow_dispatch:
@@ -29,6 +30,11 @@ on:
         description: Build from a release checkout only when selecting stable
         required: false
         default: next
+        type: string
+      release_tag:
+        description: Published or candidate release tag selecting the production source
+        required: false
+        default: ""
         type: string
 
 permissions:
@@ -60,7 +66,8 @@ jobs:
               case "$path" in
                 apps/website/* | apps/studio/docs/* | apps/studio/deployments/* | \
                 sdks/python/* | contracts/telemetry/README.md | docs/adr/* | \
-                docs/roadmaps/* | tooling/docs/* | .github/workflows/website-ci.yml)
+                docs/roadmaps/* | tooling/docs/* | .github/workflows/website-ci.yml | \
+                .github/workflows/documentation-*.yml)
                   docs_changed=true
                   break
                   ;;
@@ -81,6 +88,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
+          fetch-depth: 0
           persist-credentials: false
       - name: Set up Python
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
@@ -112,6 +120,11 @@ jobs:
       - name: Install locked dependencies
         run: npm ci
         working-directory: apps/website
+      - name: Validate release-selected stable sources
+        if: env.JUNJO_DOCS_CHANNEL == 'stable' && inputs.release_tag != ''
+        run: >-
+          python3 tooling/docs/validate_release_manifest.py
+          --release-tag "${{ inputs.release_tag }}"
       - name: Assemble source-owned documentation
         run: npm run docs:assemble
         working-directory: apps/website

--- a/.github/workflows/website-ci.yml
+++ b/.github/workflows/website-ci.yml
@@ -122,9 +122,11 @@ jobs:
         working-directory: apps/website
       - name: Validate release-selected stable sources
         if: env.JUNJO_DOCS_CHANNEL == 'stable' && inputs.release_tag != ''
+        env:
+          RELEASE_TAG: ${{ inputs.release_tag }}
         run: >-
           python3 tooling/docs/validate_release_manifest.py
-          --release-tag "${{ inputs.release_tag }}"
+          --release-tag "$RELEASE_TAG"
       - name: Assemble source-owned documentation
         run: npm run docs:assemble
         working-directory: apps/website

--- a/apps/website/AGENTS.md
+++ b/apps/website/AGENTS.md
@@ -32,6 +32,8 @@ npm audit --omit=dev --audit-level=high
 ```
 
 The production artifact is `apps/website/dist`. GitHub Actions assembles and
-validates source without retaining or deploying an artifact. After an approved
-merge, Cloudflare Pages pulls the protected `master` source, repeats the
-version-controlled build contract, and deploys its own generated output.
+validates source without retaining or deploying an artifact. Cloudflare Pages
+pulls pull-request branches and `master` as `next` previews. Only a successful
+published-release workflow may fast-forward `docs-production`; Cloudflare pulls
+that branch, repeats the version-controlled build as `stable`, and deploys its
+own generated output to `junjo.ai`.

--- a/apps/website/README.md
+++ b/apps/website/README.md
@@ -46,11 +46,17 @@ the completed production build.
 This component deliberately keeps its own `package-lock.json`; it is not part
 of a repository-wide JavaScript workspace. CI installs each documentation
 producer with its own lock and validates the complete source assembly without
-retaining or deploying its generated output. After the validated pull request
-is merged, Cloudflare Pages pulls the protected `master` commit and runs
-`tooling/docs/build_cloudflare_pages.sh` from the repository root. Cloudflare
-publishes its own generated `apps/website/dist`; that directory is never
-checked in.
+retaining or deploying its generated output. Cloudflare Pages pulls pull-request
+branches and `master`, runs `tooling/docs/build_cloudflare_pages.sh`, and
+publishes them only as `next` preview deployments. Merging does not update
+`junjo.ai`.
+
+Production uses the dedicated `docs-production` source branch and the `stable`
+channel. Python, Studio, and documentation-only release workflows validate the
+stable source set, publish the GitHub release, and only then fast-forward that
+branch to the exact release-tag commit. Cloudflare detects the ref update, pulls
+the source, generates `apps/website/dist`, and updates `junjo.ai`. GitHub never
+uploads or retains the generated site, and `dist` is never checked in.
 
 `legacy-python-api/_redirects` is source configuration, not generated site
 output. The `junjo-python-api` Cloudflare Pages project pulls that directory
@@ -58,9 +64,13 @@ from Git after the same approved merge. Its build waits for the unified Python
 landing page to be live before publishing the single permanent redirect rule.
 It must never be included in the `junjo.ai` output.
 
-CI labels ordinary source builds as `next`. A caller may request the `stable`
-channel only from the exact released checkout; the channel, SDK version, and
-full source revision are embedded in the generated pages and manifests.
+CI labels ordinary source builds as `next`. Stable assembly reads
+`tooling/docs/stable-releases.json` so independently released Python and Studio
+documentation cannot drift to unreleased `master` source. The channel, SDK
+version, release tag, and full source revision are embedded in generated
+manifests. Update the releasing component's manifest entry to its forthcoming
+exact tag in the same release commit; documentation-only releases keep the
+existing component selections.
 
 ## Content ownership
 

--- a/apps/website/astro.config.mjs
+++ b/apps/website/astro.config.mjs
@@ -1,7 +1,15 @@
 // @ts-check
+import { existsSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 import { defineConfig, passthroughImageService } from "astro/config";
 import starlight from "@astrojs/starlight";
 import tailwindcss from "@tailwindcss/vite";
+
+const hasAgentGuides = existsSync(
+  fileURLToPath(
+    new URL("./src/content/docs/generated/docs/python/agents/index.md", import.meta.url),
+  ),
+);
 
 // https://astro.build/config
 export default defineConfig({
@@ -34,14 +42,18 @@ export default defineConfig({
             { label: "Getting Started", slug: "docs/python/get-started" },
             { label: "Tutorial", slug: "docs/python/tutorial" },
             { label: "Core Concepts", slug: "docs/python/concepts" },
-            {
-              label: "Agents",
-              items: [
-                { label: "Agents", slug: "docs/python/agents" },
-                { label: "Testing", slug: "docs/python/agents/testing" },
-                { label: "Composition", slug: "docs/python/agents/composition" },
-              ],
-            },
+            ...(hasAgentGuides
+              ? [
+                  {
+                    label: "Agents",
+                    items: [
+                      { label: "Agents", slug: "docs/python/agents" },
+                      { label: "Testing", slug: "docs/python/agents/testing" },
+                      { label: "Composition", slug: "docs/python/agents/composition" },
+                    ],
+                  },
+                ]
+              : []),
             {
               label: "Workflows",
               items: [

--- a/apps/website/scripts/validate-build.mjs
+++ b/apps/website/scripts/validate-build.mjs
@@ -136,6 +136,7 @@ const sphinxBaseline = readJson(join(manifestRoot, "sphinx-api-baseline.json"));
 const contentMigration = readJson(join(manifestRoot, "content-migration.json"));
 const legacyRoutes = readJson(join(manifestRoot, "legacy-routes.json"));
 const legacyApiMap = readJson(join(manifestRoot, "legacy-api-map.json"));
+const publicationManifest = readJson(join(manifestRoot, "publication-manifest.json"));
 
 requireCondition(apiManifest.version === 1, "unsupported Python API manifest version");
 requireCondition(apiManifest.sdk === "python", "API manifest is not for the Python SDK");
@@ -144,6 +145,30 @@ requireCondition(["next", "stable"].includes(apiManifest.channel), "API manifest
 requireCondition(/^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$/.test(apiManifest.sdk_version), "invalid SDK version");
 requireCondition(/^[0-9a-f]{40}$/.test(apiManifest.source_revision), "API source revision is not a full commit SHA");
 requireCondition(apiManifest.symbol_count === apiManifest.symbols.length, "API symbol count is inconsistent");
+requireCondition(publicationManifest.version === 1, "unsupported publication manifest version");
+requireCondition(
+  publicationManifest.documentation_channel === apiManifest.channel,
+  "publication and API documentation channels differ",
+);
+requireCondition(
+  new Set(publicationManifest.routes).size === publicationManifest.routes.length,
+  "publication manifest contains duplicate routes",
+);
+requireCondition(
+  publicationManifest.python.version === apiManifest.sdk_version &&
+    publicationManifest.python.source_revision === apiManifest.source_revision,
+  "publication and API Python sources differ",
+);
+if (apiManifest.channel === "stable") {
+  requireCondition(
+    /^sdk-python-v\d+\.\d+\.\d+/.test(publicationManifest.python.release_tag),
+    "stable publication has no Python release tag",
+  );
+  requireCondition(
+    /^studio-v\d+\.\d+\.\d+/.test(publicationManifest.studio.release_tag),
+    "stable publication has no Studio release tag",
+  );
+}
 requireCondition(
   apiManifest.page_count === apiManifest.symbol_page_count + apiManifest.module_page_count + 1,
   "API page count is inconsistent",
@@ -191,11 +216,16 @@ for (const symbol of apiManifest.symbols) {
   );
 }
 
-for (const page of contentMigration.pages) {
-  requireCondition(existsSync(routeHtmlPath(page.target_route)), `migrated content route is missing: ${page.target_route}`);
+for (const route of publicationManifest.routes) {
+  requireCondition(existsSync(routeHtmlPath(route)), `published content route is missing: ${route}`);
 }
-for (const route of legacyRoutes.routes) {
-  requireCondition(existsSync(routeHtmlPath(route.target_route)), `legacy route target is missing: ${route.target_route}`);
+if (apiManifest.channel === "next") {
+  for (const page of contentMigration.pages) {
+    requireCondition(existsSync(routeHtmlPath(page.target_route)), `migrated content route is missing: ${page.target_route}`);
+  }
+  for (const route of legacyRoutes.routes) {
+    requireCondition(existsSync(routeHtmlPath(route.target_route)), `legacy route target is missing: ${route.target_route}`);
+  }
 }
 
 const expectedLegacyApiMap = new Map();
@@ -224,6 +254,6 @@ for (const htmlPath of htmlFiles) {
 }
 
 console.log(
-  `Validated ${htmlFiles.length} website pages, ${contentMigration.pages.length} migrated sources, ` +
+  `Validated ${htmlFiles.length} website pages, ${publicationManifest.routes.length} published routes, ` +
     `and ${apiManifest.symbol_count} Python API objects.`,
 );

--- a/docs/adr/0009-unified-documentation-publishing.md
+++ b/docs/adr/0009-unified-documentation-publishing.md
@@ -2,7 +2,7 @@
 
 - Status: Accepted
 - Date: 2026-07-14
-- Amended: 2026-07-15 (production deployment and legacy-domain retirement)
+- Amended: 2026-07-15 (release-gated production and legacy-domain retirement)
 - Owners: Junjo platform, SDKs, Studio, and website
 - Supersedes: the documentation publishing and isolated website-build clauses
   of [ADR 0001](0001-junjo-platform-monorepo.md)
@@ -62,14 +62,22 @@ code to generate documentation.
 - Component-owned export commands run with their own locks and native tools.
 - A version-controlled root documentation command stages the selected outputs,
   runs the normal website build, and validates the complete artifact.
-- GitHub Actions runs that contract as a pull-request validation gate, then
-  discards its generated output. It does not persist or deploy documentation
-  artifacts. Merging the validated source to protected `master` is the
-  production signal. Cloudflare Pages pulls that commit, runs the same contract,
-  and publishes its generated `apps/website/dist` directory. Build output is
-  never checked in.
+- GitHub Actions runs that contract as source validation, then discards its
+  generated output. It does not persist or deploy documentation artifacts.
+  Cloudflare Pages pulls and builds source for every same-repository pull-request
+  branch and for `master` as preview deployments. Those preview builds use the
+  explicitly labeled `next` channel and never update `junjo.ai`.
+- The Cloudflare production branch is `docs-production`. A release workflow may
+  fast-forward that branch to the exact release-tag commit only after all release
+  gates succeed and the GitHub release is published. Cloudflare then pulls that
+  source, builds it with the `stable` channel, and updates `junjo.ai`. Generated
+  `apps/website/dist` output is never checked in, uploaded by GitHub, or passed to
+  Cloudflare.
 - Stable SDK reference pages describe installable releases and record the SDK
   version and source revision.
+- A source-owned stable-release manifest pins each independently released SDK or
+  product documentation input. A component release must select its own exact tag;
+  a documentation-only release retains the existing component selections.
 - Main-branch SDK output may be published only as an explicitly labeled `next`
   preview.
 - Documentation deploys after the corresponding packages and Studio release.
@@ -91,7 +99,7 @@ is proven by the cross-component assembly workflow.
 - Sphinx dependencies and sources are retired only in a later, explicit
   cutover after the roadmap's completion criteria are satisfied.
 
-### Production Cutover Amendment (2026-07-15)
+### Initial Production Cutover Amendment (2026-07-15)
 
 The owner approved the production cutover with two explicit changes to the
 initial compatibility plan:
@@ -113,6 +121,30 @@ the migrated content. The route ledger, API baseline, Sphinx source, and final
 Sphinx artifact remain as migration evidence and rollback inputs. Sphinx may
 continue to run as a warning-strict parity check until a separate cleanup
 removes that validation dependency.
+
+### Release-Gated Production Amendment (2026-07-15)
+
+The owner subsequently separated preview publication from production promotion:
+
+- `master` is no longer a production signal and must not be merge-blocked for the
+  purpose of website deployment. GitHub validation remains visible on pull
+  requests and pushes, but repository releases retain the publication gates.
+- `docs-production` is a monotonic source pointer, not an authored branch. It is
+  initialized at the existing production commit and may advance only by
+  fast-forward to a published `sdk-python-v*`, `studio-v*`, or
+  `docs-release-YYYYMMDD.N` tag that is reachable from `master`.
+- Python and Studio release workflows validate the stable documentation set as
+  part of their release transaction and promote only after their existing
+  package or product publication succeeds. A documentation-only release runs the
+  same stable validation before promotion.
+- Cloudflare's Git integration owns every build and deployment. Production and
+  preview environment variables select `stable` and `next` respectively, and the
+  source-build contract fails closed if Cloudflare routes those channels to the
+  wrong branch.
+
+This amendment supersedes only the initial cutover's protected-`master`
+production signal. The source-build ownership, no-artifact rule, unified portal,
+content-preservation contract, and global legacy-domain redirect remain unchanged.
 
 ## Consequences
 

--- a/docs/roadmaps/MONOREPO_MIGRATION_RECORD.md
+++ b/docs/roadmaps/MONOREPO_MIGRATION_RECORD.md
@@ -174,12 +174,17 @@ The obsolete `publish.yml` publisher was removed.
 - Canonical source: `apps/website`
 - Production domain: [junjo.ai](https://junjo.ai/)
 - Restored-site commit: `d81fe0b3013310c7ec962c478c6790a0e487ba72`
-- At the time of this consolidation record, Cloudflare Pages built directly
-  from `mdrideout/junjo` on `master`. The 2026-07-15 amendment to ADR 0009
-  keeps that ownership model while making the monorepo build explicit: GitHub
-  Actions validates pull-request source without retaining an artifact, and
-  Cloudflare pulls validated `master`, repeats the version-controlled build,
-  and deploys its own output. Cloudflare preview builds are disabled.
+- Cloudflare Pages builds directly from `mdrideout/junjo`. The final 2026-07-15
+  amendment to ADR 0009 separates branches by purpose: `master` and
+  same-repository pull-request branches build automatically as `next` previews,
+  while only the release-controlled `docs-production` branch builds the
+  `stable` production site. GitHub validates source without retaining or
+  deploying an artifact; a successful published-release workflow advances only
+  the production source ref for Cloudflare to pull.
+- `docs-production` was initialized at the already-live commit
+  `6bd744ae3b86fe0daca09ecc2862295631e24557`. The control-plane cutover did not
+  replace the canonical deployment; the first subsequent published release will
+  perform the first release-gated stable production build.
 - The unified-documentation cutover completed from protected `master` commit
   `f2a19f1b9ef00a5c3935e83b37b1f8f8ffe81ab0`. Cloudflare source-built website
   deployment `8fec9dd8-20cb-4acb-8801-b89de9dd35da` serves the unified portal,

--- a/docs/roadmaps/UNIFIED_DOCUMENTATION_MIGRATION.md
+++ b/docs/roadmaps/UNIFIED_DOCUMENTATION_MIGRATION.md
@@ -1,7 +1,7 @@
 # Unified Documentation Portal Migration Strategy And Implementation Plan
 
-- Status: Production source-build cutover complete; post-cutover release-policy
-  cleanup remains
+- Status: Unified source-build cutover and release-gated production policy
+  implemented; Sphinx cleanup remains separately gated
 - Date: 2026-07-15
 - Owners: Junjo platform, Python SDK, Studio, website, and future SDK owners
 - Decision authority: ADR 0009 accepts the unified publishing boundary; the
@@ -10,10 +10,11 @@
 ## Implementation Record
 
 The repository implementation began on `codex/unified-docs-migration`. On
-2026-07-15 the owner selected Cloudflare Pages Git builds gated by validated
-merges to protected `master` and approved retirement of the legacy Sphinx site
-with a single global permanent redirect rather than page-by-page compatibility
-mappings.
+2026-07-15 the owner selected Cloudflare Pages Git builds and approved
+retirement of the legacy Sphinx site with a single global permanent redirect
+rather than page-by-page compatibility mappings. The owner then separated
+automatic preview publication from production: pull requests and `master` build
+as Cloudflare previews, while a published release is the only production signal.
 
 Implemented:
 
@@ -29,14 +30,18 @@ Implemented:
   internal link, search artifact, sitemap, and unconverted markup token;
 - a path-routed GitHub Actions workflow that validates the complete `next`
   source assembly without persisting or deploying its generated output;
-- an explicit `next`/`stable` manifest and page label, with stable assembly
-  callable only from a release-selected checkout;
+- explicit `next`/`stable` labels plus a stable source manifest that pins the
+  independently released Python and Studio inputs;
 - a version-controlled Cloudflare source-build command that repeats every
   assembly and validation gate before publishing `apps/website/dist`;
 - a committed one-rule `301` redirect source plus a legacy-domain build gate
   that waits for the unified Python landing page before retiring Sphinx; and
-- both Cloudflare Pages projects configured for automatic production builds
-  from `master`, with unvalidated branch previews disabled.
+- the unified Cloudflare Pages project configured with `docs-production` as its
+  production branch, `stable` production builds, and automatic `next` previews
+  for `master` and same-repository pull-request branches;
+- release workflows that validate stable source, require a published release,
+  and monotonically fast-forward only the production source ref; and
+- GitHub validation that retains no generated site and never calls Cloudflare.
 
 The original audit contained 4,094 RST lines. Source work that landed during
 implementation expanded the live corpus to 4,113 lines and the Sphinx API
@@ -60,11 +65,31 @@ Production evidence completed on 2026-07-15:
   `https://junjo.ai/docs/python/`. The final Sphinx deployment remains in
   Cloudflare history as a rollback input.
 
-The remaining work is post-cutover lifecycle cleanup: finish the
-release-selected stable-artifact policy, then remove Sphinx from active
-generation only when the Python release policy and CI use the replacement
-export contract. The Sphinx source and final artifact remain authoritative
-recovery inputs until those completion criteria pass.
+Release-gated control-plane evidence completed later on 2026-07-15:
+
+- `docs-production` was initialized at the already-live `master` commit
+  `6bd744ae3b86fe0daca09ecc2862295631e24557`, so changing the branch model did
+  not introduce a content deployment or rollback;
+- the `master` branch protection created for the initial cutover was removed,
+  while `docs-production` rejects force pushes and deletion;
+- the `junjo-website` Pages project now uses `docs-production` as its production
+  branch, enables previews for every non-production same-repository branch, and
+  keeps automatic production builds enabled only for commits reaching the
+  production branch;
+- Cloudflare production configuration sets `JUNJO_DOCS_CHANNEL=stable`, preview
+  configuration sets `JUNJO_DOCS_CHANNEL=next`, and both keep dependency
+  installation under the version-controlled build command; and
+- `junjo.ai` remained attached to the previous successful canonical deployment
+  during this control-plane change. A future published release, not this
+  migration merge, will trigger the first release-gated stable production build.
+
+The remaining work is the separately gated Sphinx lifecycle cleanup. Stable
+builds already regenerate the selected released Python API through the Griffe
+contract, including an explicit build-time RST conversion for the final
+pre-migration SDK release. Sphinx can leave active generation only when the
+Python release policy and CI no longer need that historical input. The Sphinx
+source and final artifact remain authoritative recovery inputs until those
+completion criteria pass.
 
 ## Objective
 
@@ -556,25 +581,33 @@ commands and stages their output before the normal website build.
 
 ### Recommended Production Pipeline
 
-Use GitHub Actions to assemble and validate pull-request source without
-persisting its generated output. Required review and validation complete before
-the source reaches protected `master`. That merge is the production signal:
-Cloudflare Pages pulls the approved commit, runs the version-controlled root
-build contract, and deploys its own generated output. Cloudflare preview builds
-remain disabled so unapproved commits are never deployed.
+Use GitHub Actions to assemble and validate source without persisting generated
+output. Cloudflare independently pulls same-repository pull-request branches and
+`master`, runs the version-controlled root build contract, and exposes `next`
+preview deployments. Merge is not a production signal.
+
+Production follows published releases. The release transaction validates the
+stable manifest and complete site, publishes the component or documentation
+release, and then fast-forwards `docs-production` to the exact release-tag
+commit. Cloudflare pulls that source, builds the selected released inputs as
+`stable`, and updates `junjo.ai`. GitHub neither uploads a site nor calls a
+Cloudflare deployment API.
 
 The production sequence is:
 
-1. obtain the selected released SDK documentation artifacts;
+1. select exact released component sources in `stable-releases.json`;
 2. stage platform, Studio, and SDK content into an ignored assembly tree;
 3. run Starlight content and TypeScript checks;
 4. build the static site;
 5. validate links, routes, anchors, symbol manifests, search, sitemap, and
    version metadata;
-6. merge the validated source to protected `master`;
-7. let Cloudflare independently repeat the complete build contract and deploy
-   only if it passes; and
-8. retire the Sphinx domain only after the unified Python landing page is live.
+6. publish an `sdk-python-v*`, `studio-v*`, or `docs-release-YYYYMMDD.N` GitHub
+   release only after its existing release gates pass;
+7. fast-forward `docs-production` to that exact release commit;
+8. let Cloudflare independently repeat the complete stable build contract and
+   deploy only if it passes; and
+9. retain the global Sphinx-domain redirect after the unified Python landing
+   page is live.
 
 For pull requests, a cross-component public-docs workflow builds `next` output
 from the changed source tree. It is triggered by:
@@ -768,9 +801,11 @@ Tasks:
 
 - produce versioned docs artifacts with SDK releases;
 - assemble stable production docs from released artifacts;
-- publish an optional clearly labeled `next` preview;
+- publish clearly labeled `next` previews automatically for `master` and
+  same-repository pull requests;
 - validate pull-request source in GitHub without persisting generated output;
-- merge approved source and let Cloudflare pull, build, and deploy it;
+- publish a GitHub release, fast-forward `docs-production`, and let Cloudflare
+  pull, build, and deploy the exact release source;
 - run production route, search, sitemap, canonical, and version checks; and
 - retain the prior website and final Sphinx artifacts as rollback inputs.
 

--- a/sdks/python/docs/export_api.py
+++ b/sdks/python/docs/export_api.py
@@ -26,7 +26,6 @@ import griffe
 
 SDK_ROOT = Path(__file__).resolve().parents[1]
 REPOSITORY_ROOT = SDK_ROOT.parents[1]
-SOURCE_ROOT = SDK_ROOT / "src"
 DEFAULT_BASELINE = Path(__file__).with_name("api-sphinx-baseline.json")
 API_PREFIX = "/docs/python/api"
 
@@ -92,7 +91,7 @@ def module_route(module: str) -> str:
     return f"{API_PREFIX}/{slug_for_symbol(module)}/"
 
 
-def source_revision(explicit: str | None) -> str:
+def source_revision(explicit: str | None, repository_root: Path = REPOSITORY_ROOT) -> str:
     if explicit:
         return explicit
     environment = os.environ.get("JUNJO_DOCS_REVISION")
@@ -100,7 +99,7 @@ def source_revision(explicit: str | None) -> str:
         return environment
     result = subprocess.run(
         ["git", "rev-parse", "HEAD"],
-        cwd=REPOSITORY_ROOT,
+        cwd=repository_root,
         check=True,
         capture_output=True,
         text=True,
@@ -108,10 +107,10 @@ def source_revision(explicit: str | None) -> str:
     return result.stdout.strip()
 
 
-def package_version(explicit: str | None) -> str:
+def package_version(explicit: str | None, sdk_root: Path = SDK_ROOT) -> str:
     if explicit:
         return explicit
-    with (SDK_ROOT / "pyproject.toml").open("rb") as handle:
+    with (sdk_root / "pyproject.toml").open("rb") as handle:
         project = tomllib.load(handle)["project"]
     return str(project["version"])
 
@@ -137,10 +136,17 @@ def sphinx_baseline_payload(inventory_path: Path) -> dict[str, Any]:
                     "legacy_anchor": anchor,
                 }
             )
+    documented_modules = {
+        entry["name"] for entry in objects if entry["kind"] == "py:module"
+    }
     return {
         "version": 1,
         "source_inventory_hash": sha256_bytes(inventory_bytes),
-        "module_allowlist": [section.module for section in MODULE_SECTIONS],
+        "module_allowlist": [
+            section.module
+            for section in MODULE_SECTIONS
+            if section.module in documented_modules
+        ],
         "objects": sorted(objects, key=lambda item: (item["kind"], item["name"])),
     }
 
@@ -165,10 +171,26 @@ def check_sphinx_baseline(inventory_path: Path, baseline_path: Path) -> None:
 
 def load_baseline(path: Path) -> dict[str, Any]:
     payload = json.loads(path.read_text(encoding="utf-8"))
-    expected_modules = [section.module for section in MODULE_SECTIONS]
-    if payload.get("module_allowlist") != expected_modules:
-        raise ValueError("Sphinx API baseline module allowlist does not match export configuration")
+    documented_modules = {
+        entry["name"]
+        for entry in payload.get("objects", [])
+        if entry.get("kind") == "py:module"
+    }
+    known_sections = {section.module: section for section in MODULE_SECTIONS}
+    module_allowlist = payload.get("module_allowlist")
+    if not isinstance(module_allowlist, list):
+        raise ValueError("Sphinx API baseline has no module allowlist")
+    if set(module_allowlist) != documented_modules:
+        raise ValueError("Sphinx API baseline module allowlist does not match its module inventory")
+    unknown_modules = sorted(documented_modules - known_sections.keys())
+    if unknown_modules:
+        raise ValueError(f"Sphinx API baseline contains unsupported modules: {unknown_modules}")
     return payload
+
+
+def module_sections_for_baseline(baseline: dict[str, Any]) -> tuple[ModuleSection, ...]:
+    allowed = set(baseline["module_allowlist"])
+    return tuple(section for section in MODULE_SECTIONS if section.module in allowed)
 
 
 def page_symbols(baseline: dict[str, Any]) -> list[str]:
@@ -382,14 +404,14 @@ def render_docstring(
     return "\n\n".join(part for part in rendered if part).strip()
 
 
-def source_link(obj: Any, revision: str) -> str | None:
+def source_link(obj: Any, revision: str, repository_root: Path) -> str | None:
     filepath = getattr(obj, "filepath", None)
     lineno = getattr(obj, "lineno", None)
     if filepath is None or lineno is None:
         return None
     path = Path(filepath).resolve()
     try:
-        relative = path.relative_to(REPOSITORY_ROOT)
+        relative = path.relative_to(repository_root)
     except ValueError:
         return None
     return f"https://github.com/mdrideout/junjo/blob/{revision}/{relative.as_posix()}#L{lineno}"
@@ -432,6 +454,7 @@ def render_member(
     member: Any,
     kind: str,
     revision: str,
+    repository_root: Path,
     symbol_links: dict[str, tuple[str, str]],
 ) -> str:
     name = public_path.rsplit(".", 1)[-1]
@@ -439,7 +462,7 @@ def render_member(
     signature = signature_for(member)
     if signature:
         output.extend(("```python", signature, "```", ""))
-    link = source_link(member, revision)
+    link = source_link(member, revision, repository_root)
     if link:
         output.extend((f"[View source]({link})", ""))
     docs = render_docstring(getattr(member, "docstring", None), 4, page_path, symbol_links)
@@ -458,6 +481,7 @@ def render_object_members(
     obj: Any,
     entries: list[dict[str, str]],
     revision: str,
+    repository_root: Path,
     symbol_links: dict[str, tuple[str, str]],
 ) -> list[str]:
     member_entries = [
@@ -482,6 +506,7 @@ def render_object_members(
                     member,
                     entry["kind"],
                     revision,
+                    repository_root,
                     symbol_links,
                 ),
             )
@@ -506,6 +531,7 @@ def render_object_page(
     version: str,
     revision: str,
     channel: str,
+    repository_root: Path,
     symbol_links: dict[str, tuple[str, str]],
 ) -> str:
     title = public_path.rsplit(".", 1)[-1]
@@ -535,7 +561,7 @@ def render_object_page(
     signature = signature_for(obj)
     if signature:
         output.extend(("## Signature", "", "```python", signature, "```", ""))
-    link = source_link(obj, revision)
+    link = source_link(obj, revision, repository_root)
     if link:
         output.extend((f"[View source]({link})", ""))
     docs = render_docstring(getattr(obj, "docstring", None), 2, public_path, symbol_links)
@@ -553,6 +579,7 @@ def render_object_page(
             obj=obj,
             entries=entries,
             revision=revision,
+            repository_root=repository_root,
             symbol_links=symbol_links,
         )
     )
@@ -593,6 +620,7 @@ def render_api_index(
     revision: str,
     channel: str,
 ) -> str:
+    has_agents = any(section.module.startswith("junjo.agent.") for section, _ in sections)
     output = [
         "---",
         'title: "Python API Reference"',
@@ -613,11 +641,16 @@ def render_api_index(
             else "This reference is generated from the released source revision."
         ),
         "",
-        "The common Agent definition and binding types are also available from `junjo`. "
-        "Provider-neutral messages, results, and typed errors live in `junjo.agent`, and "
-        "deterministic scripted testing support is public at `junjo.agent.testing`.",
-        "",
     ]
+    if has_agents:
+        output.extend(
+            (
+                "The common Agent definition and binding types are also available from `junjo`. "
+                "Provider-neutral messages, results, and typed errors live in `junjo.agent`, and "
+                "deterministic scripted testing support is public at `junjo.agent.testing`.",
+                "",
+            )
+        )
     for section, symbols in sections:
         output.extend((f"## {section.title}", "", f"Module: [`{section.module}`]({module_route(section.module)})", ""))
         if section.introduction:
@@ -628,8 +661,17 @@ def render_api_index(
     return "\n".join(output).rstrip() + "\n"
 
 
-def generate_api(output: Path, baseline_path: Path, version: str, revision: str, channel: str) -> None:
+def generate_api(
+    output: Path,
+    baseline_path: Path,
+    version: str,
+    revision: str,
+    channel: str,
+    sdk_root: Path = SDK_ROOT,
+) -> None:
     baseline = load_baseline(baseline_path)
+    module_sections = module_sections_for_baseline(baseline)
+    repository_root = sdk_root.parents[1]
     pages = page_symbols(baseline)
     baseline_entries: list[dict[str, str]] = baseline["objects"]
     symbol_links: dict[str, tuple[str, str]] = {}
@@ -645,7 +687,9 @@ def generate_api(output: Path, baseline_path: Path, version: str, revision: str,
         symbol_links[entry["legacy_anchor"]] = link
     stderr = io.StringIO()
     with contextlib.redirect_stderr(stderr):
-        package = griffe.load("junjo", search_paths=[SOURCE_ROOT], docstring_parser="auto")
+        package = griffe.load(
+            "junjo", search_paths=[sdk_root / "src"], docstring_parser="auto"
+        )
 
     output.mkdir(parents=True, exist_ok=True)
     manifest_symbols: list[dict[str, str]] = []
@@ -659,6 +703,7 @@ def generate_api(output: Path, baseline_path: Path, version: str, revision: str,
                 version,
                 revision,
                 channel,
+                repository_root,
                 symbol_links,
             )
         path = output_path_for_symbol(output, public_path)
@@ -666,7 +711,7 @@ def generate_api(output: Path, baseline_path: Path, version: str, revision: str,
         path.write_text(page_content, encoding="utf-8")
 
     sections: list[tuple[ModuleSection, list[str]]] = []
-    for section in MODULE_SECTIONS:
+    for section in module_sections:
         symbols = [
             page
             for page in pages
@@ -726,17 +771,28 @@ def generate_api(output: Path, baseline_path: Path, version: str, revision: str,
         "module_page_count": module_page_count,
         "symbol_count": len(manifest_symbols),
         "symbols": manifest_symbols,
-        "griffe_diagnostics": [line for line in stderr.getvalue().splitlines() if line.strip()],
+        "griffe_diagnostics": [
+            line.replace(f"{repository_root.resolve()}/", "")
+            for line in stderr.getvalue().splitlines()
+            if line.strip()
+        ],
     }
     manifest_path = output / "api-manifest.json"
     manifest_path.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
     print(f"Generated {page_count} API pages covering {len(manifest_symbols)} Sphinx objects.")
 
 
-def check_generation(output: Path, baseline: Path, version: str, revision: str, channel: str) -> None:
+def check_generation(
+    output: Path,
+    baseline: Path,
+    version: str,
+    revision: str,
+    channel: str,
+    sdk_root: Path = SDK_ROOT,
+) -> None:
     with tempfile_directory() as temporary:
         expected_root = temporary / "expected"
-        generate_api(expected_root, baseline, version, revision, channel)
+        generate_api(expected_root, baseline, version, revision, channel, sdk_root)
         expected_files = {
             path.relative_to(expected_root): path.read_bytes() for path in expected_root.rglob("*") if path.is_file()
         }
@@ -779,6 +835,7 @@ def main() -> int:
     generate_parser.add_argument("--baseline", type=Path, default=DEFAULT_BASELINE)
     generate_parser.add_argument("--version")
     generate_parser.add_argument("--revision")
+    generate_parser.add_argument("--sdk-root", type=Path, default=SDK_ROOT)
     generate_parser.add_argument(
         "--channel", choices=("next", "stable"), default=os.environ.get("JUNJO_DOCS_CHANNEL", "next")
     )
@@ -789,6 +846,7 @@ def main() -> int:
     check_parser.add_argument("--baseline", type=Path, default=DEFAULT_BASELINE)
     check_parser.add_argument("--version")
     check_parser.add_argument("--revision")
+    check_parser.add_argument("--sdk-root", type=Path, default=SDK_ROOT)
     check_parser.add_argument(
         "--channel", choices=("next", "stable"), default=os.environ.get("JUNJO_DOCS_CHANNEL", "next")
     )
@@ -801,14 +859,30 @@ def main() -> int:
         check_sphinx_baseline(args.inventory, args.baseline)
         return 0
 
-    version = package_version(args.version)
-    revision = source_revision(args.revision)
+    sdk_root = args.sdk_root.resolve()
+    repository_root = sdk_root.parents[1]
+    version = package_version(args.version, sdk_root)
+    revision = source_revision(args.revision, repository_root)
     if args.command == "generate":
         if args.clean and args.output.exists():
             shutil.rmtree(args.output)
-        generate_api(args.output, args.baseline, version, revision, args.channel)
+        generate_api(
+            args.output,
+            args.baseline,
+            version,
+            revision,
+            args.channel,
+            sdk_root,
+        )
         return 0
-    check_generation(args.output, args.baseline, version, revision, args.channel)
+    check_generation(
+        args.output,
+        args.baseline,
+        version,
+        revision,
+        args.channel,
+        sdk_root,
+    )
     return 0
 
 

--- a/tooling/docs/README.md
+++ b/tooling/docs/README.md
@@ -42,17 +42,21 @@ python3 tooling/docs/assemble_public_docs.py --write
 python3 tooling/docs/assemble_public_docs.py --check
 ```
 
-The default channel is `next`. A release workflow can set
-`JUNJO_DOCS_CHANNEL=stable` only while checked out at the corresponding released
-source revision. The channel is visible on API pages and recorded in both
-manifests, so an unreleased source preview cannot silently masquerade as stable
-documentation.
+The default channel is `next`. A release workflow sets
+`JUNJO_DOCS_CHANNEL=stable` and resolves the independently released inputs in
+`stable-releases.json`. The Python API is regenerated from the exact selected
+SDK revision. The channel, releases, and immutable source revisions are recorded
+in the generated manifests, so an unreleased source preview cannot silently
+masquerade as stable documentation. The initial Python release predates the
+owned Markdown export, so its RST is converted at build time; the initial Studio
+entry explicitly records the reviewed migration snapshot. Each component's next
+release replaces its exceptional migration input with its exact release tag.
 
 ## Cloudflare deployment
 
-Cloudflare Pages owns production builds through its Git integration. The
-`junjo-website` project runs this version-controlled command from the repository
-root:
+Cloudflare Pages owns preview and production builds through its Git integration.
+The `junjo-website` project runs this version-controlled command from the
+repository root:
 
 ```bash
 bash tooling/docs/build_cloudflare_pages.sh
@@ -61,12 +65,22 @@ bash tooling/docs/build_cloudflare_pages.sh
 The build output is `apps/website/dist`. The script installs a pinned `uv`,
 builds and validates the Sphinx parity source, validates the narrative ledger,
 assembles the source-owned exports, runs all Starlight checks, and audits
-production dependencies. GitHub Actions independently runs the same gates as a
-pull-request validator, but does not upload, retain, or deploy its generated
-output. Merging the validated source to protected `master` is the production
-signal; Cloudflare then pulls, builds, and deploys that commit. Automatic
-production builds are enabled for `master`, while Cloudflare branch previews
-are disabled so unvalidated source is never deployed.
+production dependencies. GitHub Actions independently runs the same gates but
+does not upload, retain, or deploy generated output.
+
+Cloudflare's production branch is `docs-production`; its production environment
+sets `JUNJO_DOCS_CHANNEL=stable`. All other same-repository branches, including
+`master` and pull-request heads, build automatically as previews with
+`JUNJO_DOCS_CHANNEL=next`. The source-build script rejects a production/preview
+channel mismatch. Cloudflare preview deployments do not apply to forked pull
+requests.
+
+Release workflows use `promote_production_branch.py` only after the corresponding
+GitHub release is published. The script verifies the live tag, `master`
+reachability, and a monotonic fast-forward before updating `docs-production`.
+It does not build, upload, or deploy the website; Cloudflare observes that ref,
+pulls the exact source, and owns the production build. Website-only changes ship
+with a published `docs-release-YYYYMMDD.N` tag after stable validation.
 
 The `junjo-python-api` project runs
 `tooling/docs/build_legacy_python_redirect.sh`, which waits for the unified

--- a/tooling/docs/assemble_public_docs.py
+++ b/tooling/docs/assemble_public_docs.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import contextlib
 import hashlib
 import json
 import os
@@ -11,6 +12,9 @@ import shutil
 import subprocess
 import sys
 import tempfile
+import tomllib
+from collections.abc import Iterator
+from dataclasses import dataclass
 from pathlib import Path
 
 REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
@@ -22,7 +26,25 @@ ASSEMBLY_RECORD = WEBSITE_ROOT / ".docs-assembly/manifest.json"
 LEGACY_SITE_OUTPUT = WEBSITE_ROOT / ".docs-assembly/python-api-site"
 LEGACY_SITE_SOURCE = WEBSITE_ROOT / "legacy-python-api"
 PYTHON_ROOT = REPOSITORY_ROOT / "sdks/python"
+STABLE_RELEASES = REPOSITORY_ROOT / "tooling/docs/stable-releases.json"
 DOCUMENTATION_CHANNEL = os.environ.get("JUNJO_DOCS_CHANNEL", "next")
+
+
+@dataclass(frozen=True)
+class ComponentSource:
+    name: str
+    version: str
+    release_tag: str
+    release_revision: str
+    documentation_revision: str
+    content_format: str
+    root: Path
+
+
+@dataclass(frozen=True)
+class DocumentationSources:
+    python: ComponentSource
+    studio: ComponentSource
 
 
 def sha256_file(path: Path) -> str:
@@ -43,45 +65,298 @@ def copy_tree_without_overwrite(source: Path, destination: Path) -> None:
         shutil.copy2(source_path, target)
 
 
-def run_python_api_export(output: Path) -> None:
+def git_output(*arguments: str) -> str:
+    result = subprocess.run(
+        ["git", *arguments],
+        cwd=REPOSITORY_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+def resolve_git_ref(reference: str) -> str:
+    try:
+        return git_output("rev-parse", "--verify", f"{reference}^{{commit}}")
+    except subprocess.CalledProcessError:
+        if reference.startswith(("sdk-python-v", "studio-v", "docs-release-")):
+            subprocess.run(
+                [
+                    "git",
+                    "fetch",
+                    "--force",
+                    "origin",
+                    f"refs/tags/{reference}:refs/tags/{reference}",
+                ],
+                cwd=REPOSITORY_ROOT,
+                check=True,
+            )
+        else:
+            subprocess.run(
+                ["git", "fetch", "--no-tags", "origin", reference],
+                cwd=REPOSITORY_ROOT,
+                check=True,
+            )
+        return git_output("rev-parse", "--verify", f"{reference}^{{commit}}")
+
+
+def python_version(root: Path) -> str:
+    with (root / "sdks/python/pyproject.toml").open("rb") as handle:
+        return str(tomllib.load(handle)["project"]["version"])
+
+
+def studio_version(root: Path) -> str:
+    payload = json.loads(
+        (root / "apps/studio/frontend/package.json").read_text(encoding="utf-8")
+    )
+    return str(payload["version"])
+
+
+def load_stable_manifest() -> dict[str, object]:
+    manifest = json.loads(STABLE_RELEASES.read_text(encoding="utf-8"))
+    if manifest.get("version") != 1:
+        raise ValueError("unsupported stable documentation manifest version")
+    return manifest
+
+
+def component_entry_fields(name: str, entry: object) -> tuple[str, str, str, str, bool]:
+    if not isinstance(entry, dict):
+        raise ValueError(f"stable documentation manifest has no {name} entry")
+    required = {
+        "version",
+        "release_tag",
+        "documentation_ref",
+        "content_format",
+        "migration_snapshot",
+    }
+    if set(entry) != required:
+        raise ValueError(
+            f"stable {name} entry must contain exactly {sorted(required)}"
+        )
+    version = entry["version"]
+    release_tag = entry["release_tag"]
+    documentation_ref = entry["documentation_ref"]
+    content_format = entry["content_format"]
+    migration_snapshot = entry["migration_snapshot"]
+    if not all(isinstance(value, str) for value in (version, release_tag, documentation_ref, content_format)):
+        raise ValueError(f"stable {name} string fields are invalid")
+    if not isinstance(migration_snapshot, bool):
+        raise ValueError(f"stable {name} migration_snapshot must be boolean")
+
+    expected_tag = (
+        f"sdk-python-v{version}" if name == "python" else f"studio-v{version}"
+    )
+    if release_tag != expected_tag:
+        raise ValueError(
+            f"stable {name} release tag must be {expected_tag}, received {release_tag}"
+        )
+    allowed_formats = {"owned-markdown"}
+    if name == "python":
+        allowed_formats.add("sphinx-rst")
+    if content_format not in allowed_formats:
+        raise ValueError(f"unsupported stable {name} content format: {content_format}")
+    return version, release_tag, documentation_ref, content_format, migration_snapshot
+
+
+def validate_component_entry(
+    name: str, entry: object, checkout_root: Path
+) -> ComponentSource:
+    version, release_tag, documentation_ref, content_format, migration_snapshot = (
+        component_entry_fields(name, entry)
+    )
+
+    release_revision = resolve_git_ref(release_tag)
+    documentation_revision = resolve_git_ref(documentation_ref)
+    if not migration_snapshot and documentation_revision != release_revision:
+        raise ValueError(
+            f"stable {name} documentation must come from its exact release tag"
+        )
+    if migration_snapshot:
+        git_output("merge-base", "--is-ancestor", release_revision, documentation_revision)
+
+    checkout = checkout_root / name
     subprocess.run(
-        [
-            "uv",
-            "run",
-            "--frozen",
-            "--extra",
-            "dev",
-            "python",
-            "docs/export_api.py",
-            "generate",
-            "--clean",
-            "--output",
-            str(output),
-            "--channel",
-            DOCUMENTATION_CHANNEL,
-        ],
-        cwd=PYTHON_ROOT,
+        ["git", "worktree", "add", "--detach", str(checkout), documentation_revision],
+        cwd=REPOSITORY_ROOT,
+        check=True,
+    )
+    try:
+        actual_version = (
+            python_version(checkout) if name == "python" else studio_version(checkout)
+        )
+        if actual_version != version:
+            raise ValueError(
+                f"stable {name} documentation revision has version {actual_version}; expected {version}"
+            )
+    except Exception:
+        subprocess.run(
+            ["git", "worktree", "remove", "--force", str(checkout)],
+            cwd=REPOSITORY_ROOT,
+            check=False,
+        )
+        raise
+    return ComponentSource(
+        name=name,
+        version=version,
+        release_tag=release_tag,
+        release_revision=release_revision,
+        documentation_revision=documentation_revision,
+        content_format=content_format,
+        root=checkout,
+    )
+
+
+@contextlib.contextmanager
+def stable_documentation_sources(checkout_root: Path) -> Iterator[DocumentationSources]:
+    manifest = load_stable_manifest()
+    created: list[Path] = []
+    try:
+        python = validate_component_entry("python", manifest.get("python"), checkout_root)
+        created.append(python.root)
+        studio = validate_component_entry("studio", manifest.get("studio"), checkout_root)
+        created.append(studio.root)
+        yield DocumentationSources(python=python, studio=studio)
+    finally:
+        for checkout in reversed(created):
+            subprocess.run(
+                ["git", "worktree", "remove", "--force", str(checkout)],
+                cwd=REPOSITORY_ROOT,
+                check=False,
+            )
+
+
+def run_python_api_export(
+    output: Path,
+    *,
+    sdk_root: Path = PYTHON_ROOT,
+    baseline: Path | None = None,
+    revision: str | None = None,
+) -> None:
+    command = [
+        "uv",
+        "run",
+        "--project",
+        str(PYTHON_ROOT),
+        "python",
+        str(PYTHON_ROOT / "docs/export_api.py"),
+        "generate",
+        "--clean",
+        "--output",
+        str(output),
+        "--sdk-root",
+        str(sdk_root),
+        "--channel",
+        DOCUMENTATION_CHANNEL,
+    ]
+    if baseline is not None:
+        command.extend(("--baseline", str(baseline)))
+    if revision is not None:
+        command.extend(("--revision", revision))
+    subprocess.run(
+        command,
+        cwd=REPOSITORY_ROOT,
         check=True,
     )
 
 
-def build_assembly(root: Path) -> None:
+def build_release_sphinx_baseline(source: ComponentSource, output: Path) -> None:
+    sdk_root = source.root / "sdks/python"
+    subprocess.run(
+        ["uv", "sync", "--frozen", "--package", "junjo", "--extra", "dev"],
+        cwd=sdk_root,
+        check=True,
+    )
+    subprocess.run(
+        ["uv", "run", "sphinx-build", "-W", "-b", "html", "docs", "docs/_build/html"],
+        cwd=sdk_root,
+        check=True,
+    )
+    subprocess.run(
+        [
+            "uv",
+            "run",
+            "--project",
+            str(PYTHON_ROOT),
+            "python",
+            str(PYTHON_ROOT / "docs/export_api.py"),
+            "baseline",
+            "--inventory",
+            str(sdk_root / "docs/_build/html/objects.inv"),
+            "--output",
+            str(output),
+        ],
+        cwd=REPOSITORY_ROOT,
+        check=True,
+    )
+
+
+def export_release_rst(source: ComponentSource, output: Path) -> None:
+    subprocess.run(
+        [
+            "uv",
+            "run",
+            "--project",
+            str(REPOSITORY_ROOT / "tooling/docs"),
+            "python",
+            str(REPOSITORY_ROOT / "tooling/docs/migrate_rst.py"),
+            "--export-release",
+            "--source-docs",
+            str(source.root / "sdks/python/docs"),
+            "--output",
+            str(output),
+        ],
+        cwd=REPOSITORY_ROOT,
+        check=True,
+    )
+
+
+def documentation_route(path: Path, content: Path) -> str:
+    relative = path.relative_to(content).with_suffix("")
+    parts = list(relative.parts)
+    if parts[-1] == "index":
+        parts.pop()
+    return "/" + "/".join(parts) + "/"
+
+
+def build_assembly(root: Path, sources: DocumentationSources | None = None) -> None:
     content = root / "content"
     assets = root / "assets"
     manifests = root / "manifests"
     record_path = root / "assembly-manifest.json"
     api_export = root / "python-api"
 
-    copy_tree_without_overwrite(REPOSITORY_ROOT / "sdks/python/docs/content", content)
-    copy_tree_without_overwrite(REPOSITORY_ROOT / "apps/studio/docs/public", content)
-    run_python_api_export(api_export)
+    if sources is None:
+        python_docs_root = REPOSITORY_ROOT / "sdks/python/docs"
+        studio_root = REPOSITORY_ROOT
+        copy_tree_without_overwrite(python_docs_root / "content", content)
+        python_baseline = python_docs_root / "api-sphinx-baseline.json"
+        python_revision = git_output("rev-parse", "HEAD")
+    else:
+        python_docs_root = sources.python.root / "sdks/python/docs"
+        studio_root = sources.studio.root
+        if sources.python.content_format == "owned-markdown":
+            copy_tree_without_overwrite(python_docs_root / "content", content)
+        else:
+            export_release_rst(sources.python, content)
+        python_baseline = root / "released-sphinx-api-baseline.json"
+        build_release_sphinx_baseline(sources.python, python_baseline)
+        python_revision = sources.python.documentation_revision
+
+    copy_tree_without_overwrite(studio_root / "apps/studio/docs/public", content)
+    run_python_api_export(
+        api_export,
+        sdk_root=python_docs_root.parent,
+        baseline=python_baseline,
+        revision=python_revision,
+    )
     copy_tree_without_overwrite(api_export / "docs", content / "docs")
-    copy_tree_without_overwrite(REPOSITORY_ROOT / "sdks/python/docs/_static", assets)
+    copy_tree_without_overwrite(python_docs_root / "_static", assets)
 
     manifests.mkdir(parents=True, exist_ok=True)
     shutil.copy2(api_export / "api-manifest.json", manifests / "api-manifest.json")
     shutil.copy2(
-        REPOSITORY_ROOT / "sdks/python/docs/api-sphinx-baseline.json",
+        python_baseline,
         manifests / "sphinx-api-baseline.json",
     )
     shutil.copy2(
@@ -112,6 +387,40 @@ def build_assembly(root: Path) -> None:
         encoding="utf-8",
     )
 
+    published_routes = sorted(
+        documentation_route(path, content)
+        for path in content.rglob("*.md")
+        if path.is_file()
+    )
+    python_publication: dict[str, object] = {
+        "version": api_manifest["sdk_version"],
+        "source_revision": api_manifest["source_revision"],
+    }
+    publication_manifest: dict[str, object] = {
+        "version": 1,
+        "documentation_channel": DOCUMENTATION_CHANNEL,
+        "routes": published_routes,
+        "python": python_publication,
+    }
+    if sources is not None:
+        python_publication.update(
+            {
+                "release_tag": sources.python.release_tag,
+                "release_revision": sources.python.release_revision,
+                "content_format": sources.python.content_format,
+            }
+        )
+        publication_manifest["studio"] = {
+            "version": sources.studio.version,
+            "release_tag": sources.studio.release_tag,
+            "release_revision": sources.studio.release_revision,
+            "source_revision": sources.studio.documentation_revision,
+            "content_format": sources.studio.content_format,
+        }
+    (manifests / "publication-manifest.json").write_text(
+        json.dumps(publication_manifest, indent=2) + "\n", encoding="utf-8"
+    )
+
     files: list[dict[str, str]] = []
     for category, directory in (
         ("content", content),
@@ -139,6 +448,9 @@ def build_assembly(root: Path) -> None:
         "python_sdk_version": api_manifest["sdk_version"],
         "python_source_revision": api_manifest["source_revision"],
         "documentation_channel": api_manifest["channel"],
+        "stable_release_manifest_hash": (
+            sha256_file(STABLE_RELEASES) if sources is not None else None
+        ),
         "files": files,
     }
     record_path.write_text(json.dumps(record, indent=2) + "\n", encoding="utf-8")
@@ -224,17 +536,29 @@ def main() -> int:
 
     with tempfile.TemporaryDirectory(prefix="junjo-docs-assembly-") as directory:
         temporary = Path(directory)
+        if DOCUMENTATION_CHANNEL == "stable":
+            with stable_documentation_sources(temporary / "source-checkouts") as sources:
+                build_assembly(temporary, sources)
+                return finish_assembly(temporary, args.write)
+        if DOCUMENTATION_CHANNEL != "next":
+            raise ValueError(
+                f"JUNJO_DOCS_CHANNEL must be next or stable, received {DOCUMENTATION_CHANNEL}"
+            )
         build_assembly(temporary)
-        if args.write:
-            write_assembly(temporary)
-            record = json.loads(
-                (temporary / "assembly-manifest.json").read_text(encoding="utf-8")
-            )
-            print(
-                f"Assembled {len(record['files'])} documentation files into Starlight staging."
-            )
-            return 0
-        return check_assembly(temporary)
+        return finish_assembly(temporary, args.write)
+
+
+def finish_assembly(temporary: Path, write: bool) -> int:
+    if write:
+        write_assembly(temporary)
+        record = json.loads(
+            (temporary / "assembly-manifest.json").read_text(encoding="utf-8")
+        )
+        print(
+            f"Assembled {len(record['files'])} documentation files into Starlight staging."
+        )
+        return 0
+    return check_assembly(temporary)
 
 
 if __name__ == "__main__":

--- a/tooling/docs/build_cloudflare_pages.sh
+++ b/tooling/docs/build_cloudflare_pages.sh
@@ -4,6 +4,17 @@ set -euo pipefail
 repository_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "$repository_root"
 
+if [[ -n "${CF_PAGES_BRANCH:-}" ]]; then
+  if [[ "$CF_PAGES_BRANCH" == "docs-production" && "${JUNJO_DOCS_CHANNEL:-}" != "stable" ]]; then
+    echo "Cloudflare production builds must use JUNJO_DOCS_CHANNEL=stable" >&2
+    exit 1
+  fi
+  if [[ "$CF_PAGES_BRANCH" != "docs-production" && "${JUNJO_DOCS_CHANNEL:-next}" != "next" ]]; then
+    echo "Cloudflare preview builds must use JUNJO_DOCS_CHANNEL=next" >&2
+    exit 1
+  fi
+fi
+
 required_uv_version="0.11.7"
 if ! command -v uv >/dev/null 2>&1 || \
   [[ "$(uv --version)" != "uv ${required_uv_version} "* ]]; then

--- a/tooling/docs/migrate_rst.py
+++ b/tooling/docs/migrate_rst.py
@@ -328,8 +328,8 @@ def normalize_markdown(markdown: str) -> str:
     return markdown.strip() + "\n"
 
 
-def convert_page(page: Page) -> str:
-    source_path = PYTHON_DOCS / page.source
+def convert_page(page: Page, source_docs: Path = PYTHON_DOCS) -> str:
+    source_path = source_docs / page.source
     source = source_path.read_text(encoding="utf-8")
     warnings = io.StringIO()
     converted = rst_to_myst(
@@ -353,6 +353,26 @@ def convert_page(page: Page) -> str:
     if keywords:
         provenance += f"\n<!-- migrated-keywords: {html.escape(keywords)} -->"
     return "\n".join(frontmatter) + provenance + "\n\n" + body
+
+
+def export_release_content(source_docs: Path, output: Path) -> int:
+    """Convert the Python-owned RST present in a pre-migration SDK release."""
+    converted_pages = 0
+    for page in PAGES:
+        if page.owner != "python" or page.target is None:
+            continue
+        source_path = source_docs / page.source
+        if not source_path.is_file():
+            continue
+        target = Path(page.target).relative_to("sdks/python/docs/content")
+        destination = output / target
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        destination.write_text(convert_page(page, source_docs), encoding="utf-8")
+        converted_pages += 1
+    if converted_pages == 0:
+        raise ValueError(f"no Python RST documentation was found below {source_docs}")
+    print(f"Exported {converted_pages} released RST pages to {output}.")
+    return converted_pages
 
 
 def source_directive_blocks(source: str, directive: str) -> list[str]:
@@ -528,7 +548,23 @@ def main() -> int:
     mode = parser.add_mutually_exclusive_group(required=True)
     mode.add_argument("--write", action="store_true", help="write converted content and migration ledgers")
     mode.add_argument("--check", action="store_true", help="verify committed output is current")
+    mode.add_argument(
+        "--export-release",
+        action="store_true",
+        help="convert only Python-owned RST present in an older released source tree",
+    )
+    parser.add_argument("--source-docs", type=Path)
+    parser.add_argument("--output", type=Path)
     args = parser.parse_args()
+
+    if args.export_release:
+        if args.source_docs is None or args.output is None:
+            parser.error("--export-release requires --source-docs and --output")
+        export_release_content(args.source_docs.resolve(), args.output.resolve())
+        return 0
+
+    if args.source_docs is not None or args.output is not None:
+        parser.error("--source-docs and --output are valid only with --export-release")
 
     outputs = expected_outputs()
     if args.write:

--- a/tooling/docs/promote_production_branch.py
+++ b/tooling/docs/promote_production_branch.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""Advance the Cloudflare production source branch to a published release."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+from pathlib import Path
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+PRODUCTION_BRANCH = "docs-production"
+RELEASE_TAG = re.compile(
+    r"(?:sdk-python-v\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?|"
+    r"studio-v\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?|"
+    r"docs-release-\d{8}\.\d+)"
+)
+
+
+def run(*arguments: str, capture: bool = False) -> str:
+    result = subprocess.run(
+        list(arguments),
+        cwd=REPOSITORY_ROOT,
+        check=True,
+        capture_output=capture,
+        text=True,
+    )
+    return result.stdout.strip() if capture else ""
+
+
+def git_output(*arguments: str) -> str:
+    return run("git", *arguments, capture=True)
+
+
+def require_ancestor(ancestor: str, descendant: str, message: str) -> None:
+    result = subprocess.run(
+        ["git", "merge-base", "--is-ancestor", ancestor, descendant],
+        cwd=REPOSITORY_ROOT,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise ValueError(message)
+
+
+def published_release(repository: str, tag: str) -> dict[str, object]:
+    payload = json.loads(
+        run(
+            "gh",
+            "api",
+            f"repos/{repository}/releases/tags/{tag}",
+            capture=True,
+        )
+    )
+    if payload.get("draft") is not False or not payload.get("published_at"):
+        raise ValueError(f"GitHub release {tag} is not published")
+    if payload.get("tag_name") != tag:
+        raise ValueError(f"GitHub release lookup returned the wrong tag for {tag}")
+    return payload
+
+
+def promote(repository: str, tag: str, dry_run: bool) -> str:
+    if RELEASE_TAG.fullmatch(tag) is None:
+        raise ValueError(f"unsupported documentation release tag: {tag}")
+    published_release(repository, tag)
+
+    run(
+        "git",
+        "fetch",
+        "--force",
+        "origin",
+        "master:refs/remotes/origin/master",
+        f"{PRODUCTION_BRANCH}:refs/remotes/origin/{PRODUCTION_BRANCH}",
+        f"refs/tags/{tag}:refs/tags/{tag}",
+    )
+    target = git_output("rev-parse", "--verify", f"refs/tags/{tag}^{{commit}}")
+    current = git_output(
+        "rev-parse", "--verify", f"refs/remotes/origin/{PRODUCTION_BRANCH}^{{commit}}"
+    )
+    require_ancestor(
+        target,
+        "refs/remotes/origin/master",
+        f"release {tag} at {target} is not reachable from origin/master",
+    )
+    if current == target:
+        print(f"{PRODUCTION_BRANCH} already points to published release {tag} ({target}).")
+        return target
+    require_ancestor(
+        current,
+        target,
+        f"refusing to move {PRODUCTION_BRANCH} non-fast-forward from {current} to {target}",
+    )
+    if dry_run:
+        print(f"Validated promotion of {PRODUCTION_BRANCH} from {current} to {target}.")
+        return target
+
+    run(
+        "gh",
+        "api",
+        "--method",
+        "PATCH",
+        f"repos/{repository}/git/refs/heads/{PRODUCTION_BRANCH}",
+        "-f",
+        f"sha={target}",
+        "-F",
+        "force=false",
+    )
+    promoted = run(
+        "gh",
+        "api",
+        f"repos/{repository}/git/ref/heads/{PRODUCTION_BRANCH}",
+        "--jq",
+        ".object.sha",
+        capture=True,
+    )
+    if promoted != target:
+        raise ValueError(
+            f"{PRODUCTION_BRANCH} resolved to {promoted} after promotion; expected {target}"
+        )
+    print(f"Promoted {PRODUCTION_BRANCH} to published release {tag} ({target}).")
+    return target
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repository", default=os.environ.get("GITHUB_REPOSITORY"))
+    parser.add_argument("--release-tag", required=True)
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+    if not args.repository:
+        parser.error("--repository or GITHUB_REPOSITORY is required")
+    promote(args.repository, args.release_tag, args.dry_run)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tooling/docs/stable-releases.json
+++ b/tooling/docs/stable-releases.json
@@ -1,0 +1,17 @@
+{
+  "version": 1,
+  "python": {
+    "version": "0.64.0",
+    "release_tag": "sdk-python-v0.64.0",
+    "documentation_ref": "sdk-python-v0.64.0",
+    "content_format": "sphinx-rst",
+    "migration_snapshot": false
+  },
+  "studio": {
+    "version": "0.81.5",
+    "release_tag": "studio-v0.81.5",
+    "documentation_ref": "f2a19f1b9ef00a5c3935e83b37b1f8f8ffe81ab0",
+    "content_format": "owned-markdown",
+    "migration_snapshot": true
+  }
+}

--- a/tooling/docs/validate_release_manifest.py
+++ b/tooling/docs/validate_release_manifest.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Validate that a release publishes the intended stable documentation set."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+STABLE_RELEASES = REPOSITORY_ROOT / "tooling/docs/stable-releases.json"
+DOCS_RELEASE = re.compile(r"docs-release-\d{8}\.\d+")
+
+
+def validate_release_tag(tag: str, manifest: dict[str, object]) -> None:
+    if tag.startswith("sdk-python-v"):
+        component = "python"
+    elif tag.startswith("studio-v"):
+        component = "studio"
+    elif DOCS_RELEASE.fullmatch(tag):
+        return
+    else:
+        raise ValueError(f"unsupported documentation release tag: {tag}")
+
+    entry = manifest.get(component)
+    if not isinstance(entry, dict) or entry.get("release_tag") != tag:
+        selected = entry.get("release_tag") if isinstance(entry, dict) else None
+        raise ValueError(
+            f"{component} release {tag} cannot publish documentation selected for {selected}; "
+            "update tooling/docs/stable-releases.json in the release commit"
+        )
+    if entry.get("migration_snapshot") is not False:
+        raise ValueError(
+            f"new {component} release {tag} must retire its migration snapshot"
+        )
+    if entry.get("documentation_ref") != tag:
+        raise ValueError(
+            f"new {component} release {tag} must document its exact release tag"
+        )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--release-tag", required=True)
+    args = parser.parse_args()
+    manifest = json.loads(STABLE_RELEASES.read_text(encoding="utf-8"))
+    if manifest.get("version") != 1:
+        raise ValueError("unsupported stable documentation manifest version")
+    validate_release_tag(args.release_tag, manifest)
+    print(f"Validated stable documentation selection for {args.release_tag}.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tooling/scripts/validate_repository.py
+++ b/tooling/scripts/validate_repository.py
@@ -69,10 +69,15 @@ REQUIRED_PATHS = (
     ".github/workflows/python-ci.yml",
     ".github/workflows/python-examples-smoke.yml",
     ".github/workflows/python-publish.yml",
+    ".github/workflows/documentation-production-promotion.yml",
+    ".github/workflows/documentation-publish.yml",
     ".github/workflows/studio-deployments.yml",
     ".github/workflows/studio-docker-publish.yml",
     ".github/workflows/studio-release-validation.yml",
     ".github/workflows/website-ci.yml",
+    "tooling/docs/promote_production_branch.py",
+    "tooling/docs/stable-releases.json",
+    "tooling/docs/validate_release_manifest.py",
     "tooling/scripts/build_studio_release_evidence.py",
     "tooling/scripts/export_studio_distribution.py",
     "tooling/scripts/publish_studio_distribution.py",
@@ -402,6 +407,38 @@ def validate_website_build_contract() -> None:
         ),
         "the Cloudflare source build must run every public documentation gate",
     )
+    require(
+        'CF_PAGES_BRANCH" == "docs-production"' in cloudflare_build
+        and "Cloudflare production builds must use JUNJO_DOCS_CHANNEL=stable"
+        in cloudflare_build
+        and "Cloudflare preview builds must use JUNJO_DOCS_CHANNEL=next"
+        in cloudflare_build,
+        "Cloudflare must fail closed when production and preview channels are misrouted",
+    )
+    stable_releases = json.loads(
+        (PLATFORM_ROOT / "tooling/docs/stable-releases.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    require(
+        stable_releases.get("version") == 1
+        and stable_releases["python"]["release_tag"]
+        == f"sdk-python-v{stable_releases['python']['version']}"
+        and stable_releases["studio"]["release_tag"]
+        == f"studio-v{stable_releases['studio']['version']}",
+        "stable documentation sources must select exact component release tags",
+    )
+    promotion = (
+        PLATFORM_ROOT / ".github/workflows/documentation-production-promotion.yml"
+    ).read_text(encoding="utf-8")
+    require(
+        "tooling/docs/promote_production_branch.py" in promotion
+        and "contents: write" in promotion
+        and "upload-artifact" not in promotion
+        and "CLOUDFLARE_API_TOKEN" not in promotion
+        and "wrangler" not in promotion,
+        "release promotion must update only the production source ref for Cloudflare to pull",
+    )
     legacy_redirect = (
         PLATFORM_ROOT / "apps/website/legacy-python-api/_redirects"
     ).read_text(encoding="utf-8")
@@ -480,12 +517,14 @@ def validate_python_support_policy() -> None:
         "uses: ./.github/workflows/python-ci.yml" in python_publish
         and "uses: ./.github/workflows/python-examples-smoke.yml" in python_publish
         and "uses: ./.github/workflows/ai-chat-compose-smoke.yml" in python_publish
-        and "needs: [sdk-validation, examples-validation, compose-validation, build-release]"
+        and "uses: ./.github/workflows/website-ci.yml" in python_publish
+        and "documentation-validation" in python_publish
+        and "uses: ./.github/workflows/documentation-production-promotion.yml"
         in python_publish
         and "workflow_call:" in python_examples
         and "workflow_call:" in ai_chat_compose
         and "Run AI Chat infrastructure tests" in python_examples,
-        "PyPI publication must wait for reusable SDK, AI Chat, Compose, and release-build validation",
+        "PyPI publication must wait for SDK, AI Chat, Compose, documentation, and release-build validation",
     )
 
 
@@ -506,6 +545,9 @@ def validate_release_routing() -> None:
         PLATFORM_ROOT / "tooling/scripts/publish_studio_distribution.py"
     ).read_text(encoding="utf-8")
     platform_gate = (workflow_root / "platform-gate.yml").read_text(encoding="utf-8")
+    docs_publish = (workflow_root / "documentation-publish.yml").read_text(
+        encoding="utf-8"
+    )
     evidence_upload = studio_publish[
         studio_publish.index(
             "- name: Upload release and mirror evidence"
@@ -599,6 +641,21 @@ def validate_release_routing() -> None:
     require(
         "Publish GitHub release last" in studio_publish,
         "the GitHub release must be the final publication step",
+    )
+    require(
+        "documentation_validation:" in studio_publish
+        and "documentation_channel: stable" in studio_publish
+        and "uses: ./.github/workflows/documentation-production-promotion.yml"
+        in studio_publish
+        and "needs:\n      - validation\n      - publish_release" in studio_publish,
+        "Studio documentation must validate before release publication and promote only afterward",
+    )
+    require(
+        "startsWith(github.event.release.tag_name, 'docs-release-')" in docs_publish
+        and "documentation_channel: stable" in docs_publish
+        and "uses: ./.github/workflows/documentation-production-promotion.yml"
+        in docs_publish,
+        "documentation-only releases must validate stable sources before production promotion",
     )
     require(
         "python3 tooling/scripts/build_studio_release_evidence.py" in studio_publish,
@@ -705,6 +762,8 @@ def validate_release_routing() -> None:
         "studio-release-validation.yml",
         "studio-docker-publish.yml",
         "website-ci.yml",
+        "documentation-publish.yml",
+        "documentation-production-promotion.yml",
     )
     require(
         all(workflow not in platform_gate for workflow in forbidden_pr_workflows)

--- a/tooling/tests/test_docs_release.py
+++ b/tooling/tests/test_docs_release.py
@@ -1,0 +1,69 @@
+"""Offline tests for release-selected documentation publication."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import unittest
+from pathlib import Path
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+
+
+def load_module(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"could not load {path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class DocumentationReleaseTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.manifest = json.loads(
+            (REPOSITORY_ROOT / "tooling/docs/stable-releases.json").read_text(
+                encoding="utf-8"
+            )
+        )
+        self.validator = load_module(
+            "validate_release_manifest",
+            REPOSITORY_ROOT / "tooling/docs/validate_release_manifest.py",
+        )
+        self.promoter = load_module(
+            "promote_production_branch",
+            REPOSITORY_ROOT / "tooling/docs/promote_production_branch.py",
+        )
+
+    def test_stable_manifest_selects_versioned_component_tags(self) -> None:
+        self.assertEqual(self.manifest["version"], 1)
+        self.assertEqual(
+            self.manifest["python"]["release_tag"],
+            f"sdk-python-v{self.manifest['python']['version']}",
+        )
+        self.assertEqual(
+            self.manifest["studio"]["release_tag"],
+            f"studio-v{self.manifest['studio']['version']}",
+        )
+
+    def test_documentation_only_release_keeps_component_selection(self) -> None:
+        self.validator.validate_release_tag("docs-release-20260715.1", self.manifest)
+
+    def test_new_component_release_must_update_its_manifest_entry(self) -> None:
+        with self.assertRaisesRegex(ValueError, "update tooling/docs/stable-releases.json"):
+            self.validator.validate_release_tag("sdk-python-v0.65.0", self.manifest)
+
+    def test_production_promotion_accepts_only_owned_release_namespaces(self) -> None:
+        accepted = (
+            "sdk-python-v0.65.0",
+            "studio-v0.82.0",
+            "docs-release-20260715.1",
+        )
+        for tag in accepted:
+            self.assertIsNotNone(self.promoter.RELEASE_TAG.fullmatch(tag), tag)
+        for tag in ("v1.0.0", "master", "docs-production", "docs-release-latest"):
+            self.assertIsNone(self.promoter.RELEASE_TAG.fullmatch(tag), tag)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- make Cloudflare Pages build `master` and same-repository PR branches as `next` previews
- reserve `docs-production` for `stable` production builds and advance it only after a published release succeeds
- validate and pin independently released Python and Studio documentation sources without persisting generated site artifacts in GitHub
- wire Python, Studio, and documentation-only releases into the same monotonic production promotion contract
- record the final deployment model in ADR 0009 and the migration record

## Validation

- Python: Ruff, 327 pytest tests, ty, warning-strict Sphinx, package build, Twine
- Studio: complete `apps/studio/run-all-tests.sh` (backend, ingestion, frontend, contracts, proto)
- Website: complete `next` build (428 API objects) and `stable` released-source build (202 API objects), deterministic assembly, link/route/search/sitemap validation, npm production audit
- Repository invariants, documentation unit tests, actionlint, and Cloudflare branch/channel fail-closed checks
- Cloudflare automatically started a real preview build for this branch; `junjo.ai` remains on the prior production deployment
