### PR TITLE
Refine mobile homepage hero layout

### DIFF
--- a/apps/website/src/components/HeroField.astro
+++ b/apps/website/src/components/HeroField.astro
@@ -76,9 +76,9 @@
         if (!width || !height) return;
         mobile = width <= 760;
         const headingTop = heading.getBoundingClientRect().top - bounds.top;
-        graphBottom = (headingTop - (mobile ? 132 : 26)) * 650 / height;
+        graphBottom = (headingTop - (mobile ? 37 : 26)) * 650 / height;
         graphRight = mobile ? 940 : 562 - 20 * 1000 / width;
-        traceTop = (headingTop - 108) * 650 / height;
+        traceTop = mobile ? graphBottom + 20 * 650 / height : (headingTop - 108) * 650 / height;
         traceHeight = 650 - traceTop;
         canvas.width = Math.round(width * devicePixelRatio);
         canvas.height = Math.round(height * devicePixelRatio);

--- a/apps/website/src/pages/index.astro
+++ b/apps/website/src/pages/index.astro
@@ -61,7 +61,11 @@ import AgentSetupModal from '../components/AgentSetupModal.astro';
     .hero-content { padding: clamp(300px,44vw,360px) 24px 54px; }
     .hero-shade { background: linear-gradient(to top,#070a1299 0%,#070a12d9 30%,#070a1266 55%,#070a1200 80%); }
     h1 { font-size: clamp(42px,8.5vw,62px); max-width: 620px; }
-    .hero-actions { gap: 18px 24px; margin-top: 28px; }
+    .hero-actions { gap: 14px 18px; margin-top: 28px; }
+    .hero-actions .button, .hero-actions :global(.agent-cta) { padding: 10px 14px; min-height: 44px; }
+    .open-source-chip { gap: 8px; padding: 5px 10px; font-size: 12px; }
+    .open-source-chip svg { width: 15px; height: 15px; }
+    .license { padding-left: 8px; font-size: 11px; }
     .hero-summary { margin-top: 16px; }
   }
   @media (prefers-reduced-motion: reduce) { .hero-gradient { animation: none; } }

--- a/apps/website/src/scripts/hero/staged-routes.js
+++ b/apps/website/src/scripts/hero/staged-routes.js
@@ -117,7 +117,7 @@ export function createStagedRoutes(seed=Math.floor(Math.random()*4294967296)) {
     // Anchor the lowest swimlane's outline above the hero, in canvas units.
     const offsetY=graphBottom===undefined?0:graphBottom-graphBottomY;
     const scaleX=(graphRight-50)/(497-50);
-    const scaleY=graphBottom===undefined?1:Math.max(0,Math.min(1,graphBottom/graphHeight));
+    const scaleY=(graphBottom===undefined?1:Math.max(0,Math.min(1,graphBottom/graphHeight)))*(layout.mobile?.68:1);
     // Node spacing follows the layout; outlines keep their size and aspect ratio
     // in CSS pixels. All emitter, edge and paint geometry uses the same radii.
     const nodeRadius=layout.mobile?10:20;


### PR DESCRIPTION
Adjust the mobile homepage hero so the graph sits lower, uses less vertical space, and the execution spans begin below it. Reduce mobile CTA padding and the Open Source chip size. Desktop layout remains unchanged.

Validation: npm ci, Astro check, production build, build validation, production dependency audit, and git diff --check passed. Mobile layout was visually reviewed during refinement.
